### PR TITLE
Fix scheduler sequencing and play reset

### DIFF
--- a/src/go/core/beat/sched_test.go
+++ b/src/go/core/beat/sched_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ingyamilmolinar/tunkul/core/model"
 )
 
-func TestSchedulerFiresEveryBeat(t *testing.T) {
+func TestSchedulerStepsThroughRow(t *testing.T) {
 	m := model.NewGraph()
 	m.ToggleStep(0)
 
@@ -23,8 +23,8 @@ func TestSchedulerFiresEveryBeat(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		s.Tick()
 	}
-	if fired != 5 {
-		t.Fatalf("expected 5 beats, got %d", fired)
+	if fired != 2 {
+		t.Fatalf("expected 2 beats, got %d", fired)
 	}
 }
 


### PR DESCRIPTION
## Summary
- implement sequential beat progression in the scheduler
- reset scheduler on play
- adjust tests for sequential behaviour

## Testing
- `go test -tags test -modfile=go.test.mod ./...`
- `make wasm`

------
https://chatgpt.com/codex/tasks/task_e_6854a1b0da748331b1aaca40d913bfbd