### PR TITLE
Fix drum UI sync and scheduler play state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,4 +70,6 @@ Code structure:
   swapped during tests with `SetInputForTest` so UI logic can run headlessly.
   UI functional tests live in this package and verify button behaviour and
   layout sizing.
+- When investigating UI issues, run the program via `xvfb-run go run ./cmd/tunkul.go`
+  to reproduce behaviour in the simulator.
 

--- a/src/go/core/beat/sched.go
+++ b/src/go/core/beat/sched.go
@@ -14,6 +14,9 @@ type Scheduler struct {
 	OnBeat func(step int)
 }
 
+// Reset clears internal timers so the next Tick starts a new cycle.
+func (s *Scheduler) Reset() { s.last = time.Time{} }
+
 func NewScheduler(m *model.Graph) *Scheduler {
 	return &Scheduler{
 		Model: m,

--- a/src/go/internal/ui/game.go
+++ b/src/go/internal/ui/game.go
@@ -353,7 +353,7 @@ func (g *Game) Update() error {
 
 	// drum view logic
 	g.drum.Update()
-	if g.drum.playing && !prevPlay {
+	if g.drum.playing != prevPlay {
 		g.sched.Reset()
 	}
 	if g.drum.playing {

--- a/src/go/internal/ui/game.go
+++ b/src/go/internal/ui/game.go
@@ -62,21 +62,21 @@ type Game struct {
 	clickI, clickJ int
 
 	/* misc */
-	winW, winH  int
-	start       *uiNode // explicit “root/start” node (⇧S to set)
+	winW, winH int
+	start      *uiNode // explicit “root/start” node (⇧S to set)
 }
 
 /* ───────────────── helper: node’s screen rect ───────────────── */
 
 // Rectangle in *screen* pixels (y already includes the transport offset).
 func (g *Game) nodeScreenRect(n *uiNode) (x1, y1, x2, y2 float64) {
-	stepPx   := StepPixels(g.cam.Scale)                  // grid step in screen px
-	camScale := float64(stepPx) / float64(GridStep)      // world→screen factor
-	offX     := math.Round(g.cam.OffsetX)                // camera panning
-	offY     := math.Round(g.cam.OffsetY)
+	stepPx := StepPixels(g.cam.Scale)               // grid step in screen px
+	camScale := float64(stepPx) / float64(GridStep) // world→screen factor
+	offX := math.Round(g.cam.OffsetX)               // camera panning
+	offY := math.Round(g.cam.OffsetY)
 
-	sx   := offX + float64(stepPx*n.I)                   // sprite centre X
-	sy   := offY + float64(stepPx*n.J) + topOffset       // sprite centre Y
+	sx := offX + float64(stepPx*n.I)             // sprite centre X
+	sy := offY + float64(stepPx*n.J) + topOffset // sprite centre Y
 	size := float64(NodeSpriteSize) * camScale
 	half := size / 2
 
@@ -132,15 +132,22 @@ func (g *Game) tryAddNode(i, j int) *uiNode {
 	if n := g.nodeAt(i, j); n != nil {
 		return n
 	}
+	prevLen := len(g.graph.Row)
 	id := g.graph.AddNode(i, j)
-	n  := &uiNode{ID: id, I: i, J: j, X: float64(i * GridStep), Y: float64(j * GridStep)}
+	n := &uiNode{ID: id, I: i, J: j, X: float64(i * GridStep), Y: float64(j * GridStep)}
 
 	if g.start == nil { // first ever node becomes the start
-		g.start  = n
-		n.Start  = true
+		g.start = n
+		n.Start = true
 	}
 	g.nodes = append(g.nodes, n)
 	g.drum.Rows[0].Steps = g.graph.Row
+	if len(g.graph.Row) != prevLen {
+		for i := 1; i < len(g.drum.Rows); i++ {
+			g.drum.Rows[i].Steps = make([]bool, len(g.graph.Row))
+		}
+		g.drum.bgDirty = true
+	}
 	return n
 }
 
@@ -244,27 +251,27 @@ func (g *Game) handleEditor() {
 		g.pendingClick = true
 		g.camDragged = false
 	}
-       if !left && g.leftPrev {
-               if g.pendingClick && !g.camDragged && !shift && !right && !g.linkDrag.active {
-                       n := g.tryAddNode(g.clickI, g.clickJ)
-                       log.Printf("[game] add/select node %d,%d", g.clickI, g.clickJ)
-                       if g.sel != nil {
-                               g.sel.Selected = false
-                       }
-                       g.sel = n
-                       n.Selected = true
-               }
-               g.pendingClick = false
-               g.camDragged = false
-       }
-       if isKeyPressed(ebiten.KeyS) && g.sel != nil {
-               if g.start != nil {
-                       g.start.Start = false
-               }
-               g.start = g.sel
-               g.start.Start = true
-       }
-       g.leftPrev = left
+	if !left && g.leftPrev {
+		if g.pendingClick && !g.camDragged && !shift && !right && !g.linkDrag.active {
+			n := g.tryAddNode(g.clickI, g.clickJ)
+			log.Printf("[game] add/select node %d,%d", g.clickI, g.clickJ)
+			if g.sel != nil {
+				g.sel.Selected = false
+			}
+			g.sel = n
+			n.Selected = true
+		}
+		g.pendingClick = false
+		g.camDragged = false
+	}
+	if isKeyPressed(ebiten.KeyS) && g.sel != nil {
+		if g.start != nil {
+			g.start.Start = false
+		}
+		g.start = g.sel
+		g.start.Start = true
+	}
+	g.leftPrev = left
 }
 
 func (g *Game) handleLinkDrag(left, right bool, gx, gy float64, i, j int) {
@@ -332,9 +339,23 @@ func (g *Game) Update() error {
 		i++
 	}
 
+	prevPlay := g.drum.playing
+	oldLen := len(g.drum.Rows[0].Steps)
 	g.drum.Rows[0].Steps = g.graph.Row
+	if len(g.graph.Row) != oldLen {
+		for i := 1; i < len(g.drum.Rows); i++ {
+			if len(g.drum.Rows[i].Steps) != len(g.graph.Row) {
+				g.drum.Rows[i].Steps = make([]bool, len(g.graph.Row))
+			}
+		}
+		g.drum.bgDirty = true
+	}
+
 	// drum view logic
 	g.drum.Update()
+	if g.drum.playing && !prevPlay {
+		g.sched.Reset()
+	}
 	if g.drum.playing {
 		g.sched.BPM = g.drum.bpm
 		log.Printf("[game] tick bpm=%d", g.sched.BPM)


### PR DESCRIPTION
## Summary
- reset beat scheduler when starting playback
- sync drum row length with graph and mark background dirty
- update scheduler to support Reset method

## Testing
- `go test -tags test -modfile=go.test.mod ./...`
- `make wasm`

------
https://chatgpt.com/codex/tasks/task_e_6854a1b0da748331b1aaca40d913bfbd