### PR TITLE
Fix drum view highlighting for loops

### DIFF
--- a/src/go/internal/ui/drumview.go
+++ b/src/go/internal/ui/drumview.go
@@ -33,19 +33,18 @@ type DrumView struct {
 	bgCache []*ebiten.Image
 
 	// ui widgets (re-computed every frame)
-	playBtn image.Rectangle
-	stopBtn image.Rectangle
-	bpmBox  image.Rectangle
+	playBtn   image.Rectangle
+	stopBtn   image.Rectangle
+	bpmBox    image.Rectangle
 	lenIncBtn image.Rectangle // New button for increasing length
 	lenDecBtn image.Rectangle // New button for decreasing length
 
 	// internal ui state
-	bpm         int
-	focusBPM    bool
-	playPressed bool
-	stopPressed bool
-	highlightedEmptyBeats map[int]int64
-	Length      int // Length of the drum view, independent of graph
+	bpm           int
+	focusBPM      bool
+	playPressed   bool
+	stopPressed   bool
+	Length        int  // Length of the drum view, independent of graph
 	lenIncPressed bool // New state for length increase button
 	lenDecPressed bool // New state for length decrease button
 }
@@ -70,17 +69,15 @@ func (dv *DrumView) SetBeatLength(length int) {
 
 /* ─── ctor ─────────────────────────────────────────────────── */
 
-
 func NewDrumView(b image.Rectangle, g *model.Graph, logger *game_log.Logger) *DrumView {
 	dv := &DrumView{
-		Bounds:  b,
-		labelW:  40,
-		bpm:     120,
-		bgDirty: true,
-		Graph:   g,
-		logger:  logger,
-		highlightedEmptyBeats: make(map[int]int64),
-		Length:  8, // Default length
+		Bounds:        b,
+		labelW:        40,
+		bpm:           120,
+		bgDirty:       true,
+		Graph:         g,
+		logger:        logger,
+		Length:        8, // Default length
 		lenIncPressed: false,
 		lenDecPressed: false,
 	}
@@ -88,7 +85,6 @@ func NewDrumView(b image.Rectangle, g *model.Graph, logger *game_log.Logger) *Dr
 	dv.SetBeatLength(dv.Length) // Initialize graph's beat length
 	return dv
 }
-
 
 // SetBounds is called from Game whenever the splitter moves or the window
 // resizes; it invalidates the cached background so dimensions update next draw.
@@ -103,9 +99,9 @@ func (dv *DrumView) SetBounds(b image.Rectangle) {
 
 func (dv *DrumView) recalcButtons() {
 	// Implementation of recalcButtons
-	dv.playBtn = image.Rect(10, dv.Bounds.Min.Y+10, 90, dv.Bounds.Min.Y+50)   // Increased size
-	dv.stopBtn = image.Rect(100, dv.Bounds.Min.Y+10, 180, dv.Bounds.Min.Y+50) // Increased size
-	dv.bpmBox = image.Rect(190, dv.Bounds.Min.Y+10, 270, dv.Bounds.Min.Y+50)  // Increased size
+	dv.playBtn = image.Rect(10, dv.Bounds.Min.Y+10, 90, dv.Bounds.Min.Y+50)     // Increased size
+	dv.stopBtn = image.Rect(100, dv.Bounds.Min.Y+10, 180, dv.Bounds.Min.Y+50)   // Increased size
+	dv.bpmBox = image.Rect(190, dv.Bounds.Min.Y+10, 270, dv.Bounds.Min.Y+50)    // Increased size
 	dv.lenDecBtn = image.Rect(280, dv.Bounds.Min.Y+10, 320, dv.Bounds.Min.Y+50) // Increased size
 	dv.lenIncBtn = image.Rect(330, dv.Bounds.Min.Y+10, 370, dv.Bounds.Min.Y+50) // Increased size
 }
@@ -181,7 +177,7 @@ func (dv *DrumView) Update() {
 			if r >= '0' && r <= '9' {
 				val, _ := strconv.Atoi(string(r))
 				newBPM := dv.bpm*10 + val
-								if newBPM > 300 {
+				if newBPM > 300 {
 					newBPM = 300
 				}
 				if newBPM != dv.bpm {
@@ -208,7 +204,7 @@ func (dv *DrumView) Update() {
 			dv.Length++
 			dv.logger.Infof("[DRUMVIEW] Length increased to: %d", dv.Length)
 			dv.Rows[0].Steps = make([]bool, dv.Length) // Update the steps slice
-			dv.SetBeatLength(dv.Length) // Update graph's beat length
+			dv.SetBeatLength(dv.Length)                // Update graph's beat length
 			dv.bgDirty = true
 		}
 		dv.lenIncPressed = false
@@ -219,15 +215,15 @@ func (dv *DrumView) Update() {
 			dv.logger.Infof("[DRUMVIEW] Length decreased to: %d", dv.Length)
 			dv.logger.Infof("[DRUMVIEW] Length decreased to: %d", dv.Length)
 			dv.Rows[0].Steps = make([]bool, dv.Length) // Update the steps slice
-			dv.SetBeatLength(dv.Length) // Update graph's beat length
+			dv.SetBeatLength(dv.Length)                // Update graph's beat length
 			dv.bgDirty = true
 		}
 		dv.lenDecPressed = false
 	}
 }
 
-func (dv *DrumView) Draw(dst *ebiten.Image, highlightedNodes map[model.NodeID]int64, highlightedEmptyBeats map[int]int64, frame int64, beatInfos []model.BeatInfo) {
-	dv.logger.Debugf("[DRUMVIEW] Draw called. beatInfos: %v, highlightedNodes: %v, highlightedEmptyBeats: %v", beatInfos, highlightedNodes, highlightedEmptyBeats)
+func (dv *DrumView) Draw(dst *ebiten.Image, highlightedBeats map[int]int64, frame int64, beatInfos []model.BeatInfo) {
+	dv.logger.Debugf("[DRUMVIEW] Draw called. beatInfos: %v, highlightedBeats: %v", beatInfos, highlightedBeats)
 	// draw background
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(float64(dv.Bounds.Min.X), float64(dv.Bounds.Min.Y))
@@ -249,23 +245,13 @@ func (dv *DrumView) Draw(dst *ebiten.Image, highlightedNodes map[model.NodeID]in
 
 			// Highlighting logic
 			highlighted := false
-			isRegularNode := false
-			if len(beatInfos) > j {
-				if beatInfos[j].NodeType == model.NodeTypeRegular {
-					isRegularNode = true
-				}
-			}
+			isRegularNode := len(beatInfos) > j && beatInfos[j].NodeType == model.NodeTypeRegular
 
-			if isRegularNode {
-				if len(beatInfos) > j {
-					if _, ok := highlightedNodes[beatInfos[j].NodeID]; ok {
-						highlighted = true
-						dv.logger.Debugf("[DRUMVIEW] Draw: Highlighting regular node at index %d, NodeID: %v", j, beatInfos[j].NodeID)
-					}
-				}
-			} else { // NodeTypeInvisible or NodeTypeEmpty
-				if _, ok := highlightedEmptyBeats[j]; ok {
-					highlighted = true
+			if _, ok := highlightedBeats[j]; ok {
+				highlighted = true
+				if isRegularNode {
+					dv.logger.Debugf("[DRUMVIEW] Draw: Highlighting regular node at index %d, NodeID: %v", j, beatInfos[j].NodeID)
+				} else {
 					dv.logger.Debugf("[DRUMVIEW] Draw: Highlighting empty beat at index %d", j)
 				}
 			}

--- a/src/go/internal/ui/drumview_test.go
+++ b/src/go/internal/ui/drumview_test.go
@@ -199,7 +199,7 @@ func TestDrumViewLoopHighlighting(t *testing.T) {
 	game := New(logger)
 	game.graph = graph
 	game.drum = drumView
-	game.bpm = 120 // Set a BPM for consistent beat duration
+	game.bpm = 120        // Set a BPM for consistent beat duration
 	game.Layout(800, 720) // Set layout to initialize drum view bounds
 
 	// Simulate starting playback
@@ -207,12 +207,10 @@ func TestDrumViewLoopHighlighting(t *testing.T) {
 	game.updateBeatInfos() // Call updateBeatInfos after drum is set
 	game.spawnPulse()
 
-	
-
 	// Run for a few cycles to test loop highlighting
 	for i := 0; i < 20; i++ { // Simulate 20 frames
 		game.Update()
-		t.Logf("Frame %d: highlightedNodes: %v, highlightedEmptyBeats: %v", game.frame, game.highlightedNodes, game.drum.highlightedEmptyBeats)
+		t.Logf("Frame %d: highlightedBeats: %v", game.frame, game.highlightedBeats)
 
 		// Determine the expected highlighted index based on the current beat and loop
 		expectedHighlightedIndex := -1
@@ -230,12 +228,8 @@ func TestDrumViewLoopHighlighting(t *testing.T) {
 		// Verify highlighting
 		for j := 0; j < drumView.Length; j++ {
 			isHighlighted := false
-			if _, ok := game.drum.highlightedEmptyBeats[j]; ok {
+			if _, ok := game.highlightedBeats[j]; ok {
 				isHighlighted = true
-			} else if len(game.beatInfos) > j {
-				if _, ok := game.highlightedNodes[game.beatInfos[j].NodeID]; ok {
-					isHighlighted = true
-				}
 			}
 
 			if j == expectedHighlightedIndex {

--- a/src/go/internal/ui/game_test.go
+++ b/src/go/internal/ui/game_test.go
@@ -4,7 +4,6 @@ import (
 	"math"
 	"os"
 	"testing"
-	
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/ingyamilmolinar/tunkul/core/model"
@@ -481,27 +480,27 @@ func TestSplitterDragDoesNotCreateNode(t *testing.T) {
 }
 
 func TestStartNodeSelection(t *testing.T) {
-       g := New(testLogger)
-       g.Layout(640, 480)
-       n1 := g.tryAddNode(0, 0, model.NodeTypeRegular)
-       if g.start != n1 || !n1.Start {
-               t.Fatalf("first node should be start")
-       }
-       n2 := g.tryAddNode(1, 0, model.NodeTypeRegular)
-       g.sel = n2
-       restore := SetInputForTest(
-               func() (int, int) { return 0, topOffset + 10 },
-               func(ebiten.MouseButton) bool { return false },
-               func(k ebiten.Key) bool { return k == ebiten.KeyS },
-               func() []rune { return nil },
+	g := New(testLogger)
+	g.Layout(640, 480)
+	n1 := g.tryAddNode(0, 0, model.NodeTypeRegular)
+	if g.start != n1 || !n1.Start {
+		t.Fatalf("first node should be start")
+	}
+	n2 := g.tryAddNode(1, 0, model.NodeTypeRegular)
+	g.sel = n2
+	restore := SetInputForTest(
+		func() (int, int) { return 0, topOffset + 10 },
+		func(ebiten.MouseButton) bool { return false },
+		func(k ebiten.Key) bool { return k == ebiten.KeyS },
+		func() []rune { return nil },
 		func() (float64, float64) { return 0, 0 },
 		func() (int, int) { return 640, 480 },
-       )
-       defer restore()
-       g.Update()
-       if g.start != n2 || !n2.Start || n1.Start {
-               t.Fatalf("start node not updated")
-       }
+	)
+	defer restore()
+	g.Update()
+	if g.start != n2 || !n2.Start || n1.Start {
+		t.Fatalf("start node not updated")
+	}
 	g.graph.StartNodeID = n2.ID
 }
 
@@ -528,41 +527,31 @@ func TestHighlightEmptyCells(t *testing.T) {
 
 	g.playing = true
 	g.sched.Start()
-
-	// Set playing to true and spawn the pulse
-	g.playing = true
 	g.spawnPulse()
 
-	// Tick 0: Should highlight n1 (index 0)
-	for g.activePulse == nil || g.activePulse.pathIdx == 0 || g.activePulse.t < 1 {
-		g.Update()
-	}
-	if _, ok := g.highlightedNodes[n1.ID]; !ok {
-		t.Errorf("Tick 0: Node n1 should be highlighted")
+	if _, ok := g.highlightedBeats[0]; !ok {
+		t.Errorf("Tick 0: Beat at index 0 should be highlighted")
 	}
 
-	// Tick 1: Should highlight the first empty cell (index 1)
-	for g.activePulse.pathIdx == 1 && g.activePulse.t < 1 {
+	for g.activePulse != nil && g.activePulse.pathIdx < 2 {
 		g.Update()
 	}
-	if _, ok := g.drum.highlightedEmptyBeats[1]; !ok {
-		t.Errorf("Tick 1: Empty cell at index 1 should be highlighted")
+	if _, ok := g.highlightedBeats[1]; !ok {
+		t.Errorf("Tick 1: Beat at index 1 should be highlighted")
 	}
 
-	// Tick 2: Should highlight the second empty cell (index 2)
-	for g.activePulse.pathIdx == 2 && g.activePulse.t < 1 {
+	for g.activePulse != nil && g.activePulse.pathIdx < 3 {
 		g.Update()
 	}
-	if _, ok := g.drum.highlightedEmptyBeats[2]; !ok {
-		t.Errorf("Tick 2: Empty cell at index 2 should be highlighted")
+	if _, ok := g.highlightedBeats[2]; !ok {
+		t.Errorf("Tick 2: Beat at index 2 should be highlighted")
 	}
 
-	// Tick 3: Should highlight n2 (index 3)
-	for g.activePulse.pathIdx == 3 && g.activePulse.t < 1 {
+	for g.activePulse != nil && g.activePulse.pathIdx < 4 {
 		g.Update()
 	}
-	if _, ok := g.highlightedNodes[n2.ID]; !ok {
-		t.Errorf("Tick 3: Node n2 should be highlighted")
+	if _, ok := g.highlightedBeats[3]; !ok {
+		t.Errorf("Tick 3: Beat at index 3 should be highlighted")
 	}
 }
 
@@ -826,36 +815,26 @@ func TestSignalTraversalInLoop(t *testing.T) {
 
 	// Advance the pulse and check its path
 	maxIterations := len(expectedNodeIDs) * 100 // Safety break for infinite loops
-	for i := 0; i < len(expectedNodeIDs); i++ {
-		t.Logf("Test Loop: Iteration %d. Expected Node ID: %d", i, expectedNodeIDs[i])
-		// Simulate enough frames for the pulse to advance to the next beat
+	for step := 0; step < len(expectedNodeIDs)-1; step++ {
+		if g.activePulse == nil {
+			t.Fatalf("Pulse ended prematurely at step %d", step)
+		}
+		if g.activePulse.fromBeatInfo.NodeID != expectedNodeIDs[step] {
+			t.Errorf("Step %d: Expected NodeID %d, got %d (fromBeatInfo)", step, expectedNodeIDs[step], g.activePulse.fromBeatInfo.NodeID)
+		}
+		if g.activePulse.toBeatInfo.NodeID != expectedNodeIDs[step+1] {
+			t.Errorf("Step %d: Expected next NodeID %d, got %d (toBeatInfo)", step, expectedNodeIDs[step+1], g.activePulse.toBeatInfo.NodeID)
+		}
+
+		startIdx := g.activePulse.pathIdx
 		frameCounter := 0
-		for g.activePulse != nil && g.activePulse.t < 1 && frameCounter < maxIterations {
+		for g.activePulse != nil && g.activePulse.pathIdx == startIdx && frameCounter < maxIterations {
 			g.Update()
 			frameCounter++
-			t.Logf("  Inside inner loop: activePulse.t=%.2f, activePulse.pathIdx=%d, frameCounter=%d", g.activePulse.t, g.activePulse.pathIdx, frameCounter)
+			t.Logf("  Inside inner loop: pathIdx=%d, t=%.2f, frameCounter=%d", g.activePulse.pathIdx, g.activePulse.t, frameCounter)
 		}
 		if frameCounter >= maxIterations {
-			t.Fatalf("Inner loop exceeded max iterations (%d) at step %d, possible infinite loop. activePulse.t=%.2f, activePulse.pathIdx=%d", maxIterations, i, g.activePulse.t, g.activePulse.pathIdx)
-		}
-
-		if g.activePulse == nil {
-			if i < len(expectedNodeIDs)-1 {
-				t.Fatalf("Pulse ended prematurely at step %d", i)
-			}
-			break // Pulse has naturally ended
-		}
-
-		// The fromBeatInfo of the pulse should correspond to the expected node ID at the current step
-		if g.activePulse.fromBeatInfo.NodeID != expectedNodeIDs[i] {
-			t.Errorf("Step %d: Expected NodeID %d, got %d (fromBeatInfo)", i, expectedNodeIDs[i], g.activePulse.fromBeatInfo.NodeID)
-		}
-
-		// For all but the last step, check the toBeatInfo as well
-		if i < len(expectedNodeIDs)-1 {
-			if g.activePulse.toBeatInfo.NodeID != expectedNodeIDs[i+1] {
-				t.Errorf("Step %d: Expected next NodeID %d, got %d (toBeatInfo)", i, expectedNodeIDs[i+1], g.activePulse.toBeatInfo.NodeID)
-			}
+			t.Fatalf("Inner loop exceeded max iterations (%d) at step %d, possible infinite loop. pathIdx=%d", maxIterations, step, g.activePulse.pathIdx)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- highlight drum beats by index to avoid duplicate highlights in loops
- highlight arrival beats, including empty intersections
- expand tests for beat highlighting and loop traversal

## Testing
- `go test -tags test -modfile=go.test.mod -timeout 1s ./...`
- `make wasm`
- `make test-real` *(fails: X11 DISPLAY environment variable is missing)*
- `xvfb-run go test -timeout 1s ./...`


------
https://chatgpt.com/codex/tasks/task_e_689540f0855c8331b60f5c54a93b25e2