### PR TITLE
feat: add expanded drum synthesis and wav support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ C_LIB = build/libdrums.a
 C_SRC = src/c/drums.c src/c/miniaudio.c
 
 $(MA_JS): $(C_SRC) src/c/miniaudio.h
-	emcc $(C_SRC) -sWASM=1 -sEXPORTED_FUNCTIONS='[_render_snare,_render_kick,_render_hihat,_render_tom,_render_clap,_load_wav,_malloc,_free]' -sEXPORTED_RUNTIME_METHODS='["cwrap","ccall","HEAPF32"]' -sMODULARIZE=1 -sEXPORT_ES6=1 -o $(MA_JS)
+	emcc $(C_SRC) -sWASM=1 -sEXPORTED_FUNCTIONS='[_render_snare,_render_kick,_render_hihat,_render_tom,_render_clap,_load_wav,_result_description,_malloc,_free]' -sEXPORTED_RUNTIME_METHODS='["cwrap","ccall","HEAPF32"]' -sMODULARIZE=1 -sEXPORT_ES6=1 -o $(MA_JS)
 
 $(C_LIB): $(C_SRC)
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ C_LIB = build/libdrums.a
 C_SRC = src/c/drums.c src/c/miniaudio.c
 
 $(MA_JS): $(C_SRC) src/c/miniaudio.h
-	emcc $(C_SRC) -sWASM=1 -sEXPORTED_FUNCTIONS='[_render_snare,_render_kick,_malloc,_free]' -sEXPORTED_RUNTIME_METHODS='["cwrap","ccall","HEAPF32"]' -sMODULARIZE=1 -sEXPORT_ES6=1 -o $(MA_JS)
+	emcc $(C_SRC) -sWASM=1 -sEXPORTED_FUNCTIONS='[_render_snare,_render_kick,_render_hihat,_render_tom,_render_clap,_load_wav,_malloc,_free]' -sEXPORTED_RUNTIME_METHODS='["cwrap","ccall","HEAPF32"]' -sMODULARIZE=1 -sEXPORT_ES6=1 -o $(MA_JS)
 
 $(C_LIB): $(C_SRC)
 	mkdir -p build

--- a/src/c/drums.c
+++ b/src/c/drums.c
@@ -145,7 +145,7 @@ EXPORT int load_wav(const char *path, float **buffer, int *sampleRate) {
     return res;
   }
   *buffer = data;
-  if (sampleRate)
+  if (sampleRate != NULL)
     *sampleRate = dec.outputSampleRate;
   ma_decoder_uninit(&dec);
   return (int)frames;

--- a/src/c/drums.c
+++ b/src/c/drums.c
@@ -12,126 +12,145 @@
 #define EXPORT
 #endif
 
-EXPORT void render_snare(float* out, int sampleRate, int samples) {
-    ma_noise_config nc = ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
-    ma_noise noise;
-    if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
-        return;
-    }
-    double lp = 0.0, phase = 0.0;
-    for (int i = 0; i < samples; ++i) {
-        double t = (double)i / (double)samples;
-        float n;
-        ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
-        lp = lp * 0.7 + n * 0.3;
-        double hp = n - lp;
-        double env = exp(-6.0 * t);
-        double noiseVal = (hp * 0.5 + lp * 0.5) * env;
-        double freq = 200.0 - 60.0 * t;
-        phase += 2.0 * M_PI * freq / (double)sampleRate;
-        double tone = sin(phase) * exp(-4.0 * t);
-        out[i] = (float)(noiseVal * 0.7 + tone * 0.3);
-    }
-    ma_noise_uninit(&noise, NULL);
+EXPORT void render_snare(float *out, int sampleRate, int samples) {
+  ma_noise_config nc =
+      ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
+  ma_noise noise;
+  if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
+    return;
+  }
+  double lp = 0.0, phase = 0.0;
+  for (int i = 0; i < samples; ++i) {
+    double t = (double)i / (double)samples;
+    float n;
+    ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
+    lp = lp * 0.7 + n * 0.3;
+    double hp = n - lp;
+    double env = exp(-6.0 * t);
+    double noiseVal = (hp * 0.5 + lp * 0.5) * env;
+    double freq = 200.0 - 60.0 * t;
+    phase += 2.0 * M_PI * freq / (double)sampleRate;
+    double tone = sin(phase) * exp(-4.0 * t);
+    out[i] = (float)(noiseVal * 0.7 + tone * 0.3);
+  }
+  ma_noise_uninit(&noise, NULL);
 }
 
-EXPORT void render_kick(float* out, int sampleRate, int samples) {
-    ma_noise_config nc = ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
-    ma_noise noise;
-    if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
-        return;
-    }
-    double phase = 0.0;
-    for (int i = 0; i < samples; ++i) {
-        double t = (double)i / (double)samples;
-        float n;
-        ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
-        double freq = 150.0 - 100.0 * t;
-        phase += 2.0 * M_PI * freq / (double)sampleRate;
-        double env = exp(-5.0 * t);
-        double tone = sin(phase) * env;
-        double attack = n * exp(-40.0 * t);
-        out[i] = (float)(tone + attack);
-    }
-    ma_noise_uninit(&noise, NULL);
+EXPORT void render_kick(float *out, int sampleRate, int samples) {
+  ma_noise_config nc =
+      ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
+  ma_noise noise;
+  if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
+    return;
+  }
+  double phase = 0.0;
+  for (int i = 0; i < samples; ++i) {
+    double t = (double)i / (double)samples;
+    float n;
+    ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
+    double freq = 150.0 - 100.0 * t;
+    phase += 2.0 * M_PI * freq / (double)sampleRate;
+    double env = exp(-5.0 * t);
+    double tone = sin(phase) * env;
+    double attack = n * exp(-40.0 * t);
+    out[i] = (float)(tone + attack);
+  }
+  ma_noise_uninit(&noise, NULL);
 }
 
-EXPORT void render_hihat(float* out, int sampleRate, int samples) {
-    ma_noise_config nc = ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
-    ma_noise noise;
-    if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
-        return;
-    }
-    double lp = 0.0;
-    for (int i = 0; i < samples; ++i) {
-        double t = (double)i / (double)samples;
-        float n;
-        ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
-        lp = lp * 0.95 + n * 0.05;
-        double hp = n - lp;
-        double env = exp(-40.0 * t);
-        out[i] = (float)(hp * env);
-    }
-    ma_noise_uninit(&noise, NULL);
+EXPORT void render_hihat(float *out, int sampleRate, int samples) {
+  ma_noise_config nc =
+      ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
+  ma_noise noise;
+  if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
+    return;
+  }
+  double lp = 0.0;
+  for (int i = 0; i < samples; ++i) {
+    double t = (double)i / (double)samples;
+    float n;
+    ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
+    lp = lp * 0.95 + n * 0.05;
+    double hp = n - lp;
+    double env = exp(-40.0 * t);
+    out[i] = (float)(hp * env);
+  }
+  ma_noise_uninit(&noise, NULL);
 }
 
-EXPORT void render_tom(float* out, int sampleRate, int samples) {
-    ma_noise_config nc = ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
-    ma_noise noise;
-    if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
-        return;
-    }
-    double phase = 0.0;
-    double lp = 0.0;
-    for (int i = 0; i < samples; ++i) {
-        double t = (double)i / (double)samples;
-        float n;
-        ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
-        double freq = 300.0 - 200.0 * t;
-        phase += 2.0 * M_PI * freq / (double)sampleRate;
-        double tone = sin(phase) * exp(-3.0 * t);
-        lp = lp * 0.8 + n * 0.2;
-        double env = exp(-6.0 * t);
-        out[i] = (float)(tone + lp * 0.2 * env);
-    }
-    ma_noise_uninit(&noise, NULL);
+EXPORT void render_tom(float *out, int sampleRate, int samples) {
+  ma_noise_config nc =
+      ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
+  ma_noise noise;
+  if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
+    return;
+  }
+  double phase = 0.0;
+  double lp = 0.0;
+  for (int i = 0; i < samples; ++i) {
+    double t = (double)i / (double)samples;
+    float n;
+    ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
+    double freq = 300.0 - 200.0 * t;
+    phase += 2.0 * M_PI * freq / (double)sampleRate;
+    double tone = sin(phase) * exp(-3.0 * t);
+    lp = lp * 0.8 + n * 0.2;
+    double env = exp(-6.0 * t);
+    out[i] = (float)(tone + lp * 0.2 * env);
+  }
+  ma_noise_uninit(&noise, NULL);
 }
 
-EXPORT void render_clap(float* out, int sampleRate, int samples) {
-    ma_noise_config nc = ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
-    ma_noise noise;
-    if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
-        return;
-    }
-    for (int i = 0; i < samples; ++i) {
-        double t = (double)i / (double)sampleRate;
-        float n;
-        ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
-        double burst = exp(-100.0 * fabs(t - 0.00)) +
-                       exp(-100.0 * fabs(t - 0.02)) +
-                       exp(-100.0 * fabs(t - 0.04));
-        double env = exp(-6.0 * t);
-        out[i] = (float)(n * burst * env);
-    }
-    ma_noise_uninit(&noise, NULL);
+EXPORT void render_clap(float *out, int sampleRate, int samples) {
+  ma_noise_config nc =
+      ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
+  ma_noise noise;
+  if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
+    return;
+  }
+  for (int i = 0; i < samples; ++i) {
+    double t = (double)i / (double)sampleRate;
+    float n;
+    ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
+    double burst = exp(-100.0 * fabs(t - 0.00)) + exp(-100.0 * fabs(t - 0.02)) +
+                   exp(-100.0 * fabs(t - 0.04));
+    double env = exp(-6.0 * t);
+    out[i] = (float)(n * burst * env);
+  }
+  ma_noise_uninit(&noise, NULL);
 }
 
-EXPORT int load_wav(const char* path, float** buffer, int* sampleRate) {
-    ma_decoder_config cfg = ma_decoder_config_init(ma_format_f32, 1, 0);
-    ma_decoder dec;
-    if (ma_decoder_init_file(path, &cfg, &dec) != MA_SUCCESS) {
-        return 0;
-    }
-    ma_uint64 frames;
-    ma_decoder_get_length_in_pcm_frames(&dec, &frames);
-    float* data = (float*)malloc(frames * sizeof(float));
-    if (data == NULL) {
-        ma_decoder_uninit(&dec);
-        return 0;
-    }
-    ma_decoder_read_pcm_frames(&dec, data, frames, NULL);
-    *buffer = data;
-    if (sampleRate) *sampleRate = dec.outputSampleRate;
+EXPORT int load_wav(const char *path, float **buffer, int *sampleRate) {
+  ma_decoder_config cfg = ma_decoder_config_init(ma_format_f32, 1, 0);
+  ma_decoder dec;
+  ma_result res = ma_decoder_init_file(path, &cfg, &dec);
+  if (res != MA_SUCCESS) {
+    return res;
+  }
+  ma_uint64 frames;
+  res = ma_decoder_get_length_in_pcm_frames(&dec, &frames);
+  if (res != MA_SUCCESS) {
     ma_decoder_uninit(&dec);
-    return (int)frames;
+    return res;
+  }
+  float *data = (float *)malloc(frames * sizeof(float));
+  if (data == NULL) {
+    ma_decoder_uninit(&dec);
+    return MA_OUT_OF_MEMORY;
+  }
+  res = ma_decoder_read_pcm_frames(&dec, data, frames, NULL);
+  if (res != MA_SUCCESS) {
+    free(data);
+    ma_decoder_uninit(&dec);
+    return res;
+  }
+  *buffer = data;
+  if (sampleRate)
+    *sampleRate = dec.outputSampleRate;
+  ma_decoder_uninit(&dec);
+  return (int)frames;
+}
+
+EXPORT const char *result_description(int code) {
+  return ma_result_description((ma_result)code);
 }

--- a/src/c/drums.c
+++ b/src/c/drums.c
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <stdlib.h>
 
 #define MA_NO_DEVICE_IO
 #define MA_NO_THREADING
@@ -53,4 +54,84 @@ EXPORT void render_kick(float* out, int sampleRate, int samples) {
         out[i] = (float)(tone + attack);
     }
     ma_noise_uninit(&noise, NULL);
+}
+
+EXPORT void render_hihat(float* out, int sampleRate, int samples) {
+    ma_noise_config nc = ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
+    ma_noise noise;
+    if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
+        return;
+    }
+    double lp = 0.0;
+    for (int i = 0; i < samples; ++i) {
+        double t = (double)i / (double)samples;
+        float n;
+        ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
+        lp = lp * 0.95 + n * 0.05;
+        double hp = n - lp;
+        double env = exp(-40.0 * t);
+        out[i] = (float)(hp * env);
+    }
+    ma_noise_uninit(&noise, NULL);
+}
+
+EXPORT void render_tom(float* out, int sampleRate, int samples) {
+    ma_noise_config nc = ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
+    ma_noise noise;
+    if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
+        return;
+    }
+    double phase = 0.0;
+    double lp = 0.0;
+    for (int i = 0; i < samples; ++i) {
+        double t = (double)i / (double)samples;
+        float n;
+        ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
+        double freq = 300.0 - 200.0 * t;
+        phase += 2.0 * M_PI * freq / (double)sampleRate;
+        double tone = sin(phase) * exp(-3.0 * t);
+        lp = lp * 0.8 + n * 0.2;
+        double env = exp(-6.0 * t);
+        out[i] = (float)(tone + lp * 0.2 * env);
+    }
+    ma_noise_uninit(&noise, NULL);
+}
+
+EXPORT void render_clap(float* out, int sampleRate, int samples) {
+    ma_noise_config nc = ma_noise_config_init(ma_format_f32, 1, ma_noise_type_white, 0, 1.0);
+    ma_noise noise;
+    if (ma_noise_init(&nc, NULL, &noise) != MA_SUCCESS) {
+        return;
+    }
+    for (int i = 0; i < samples; ++i) {
+        double t = (double)i / (double)sampleRate;
+        float n;
+        ma_noise_read_pcm_frames(&noise, &n, 1, NULL);
+        double burst = exp(-100.0 * fabs(t - 0.00)) +
+                       exp(-100.0 * fabs(t - 0.02)) +
+                       exp(-100.0 * fabs(t - 0.04));
+        double env = exp(-6.0 * t);
+        out[i] = (float)(n * burst * env);
+    }
+    ma_noise_uninit(&noise, NULL);
+}
+
+EXPORT int load_wav(const char* path, float** buffer, int* sampleRate) {
+    ma_decoder_config cfg = ma_decoder_config_init(ma_format_f32, 1, 0);
+    ma_decoder dec;
+    if (ma_decoder_init_file(path, &cfg, &dec) != MA_SUCCESS) {
+        return 0;
+    }
+    ma_uint64 frames;
+    ma_decoder_get_length_in_pcm_frames(&dec, &frames);
+    float* data = (float*)malloc(frames * sizeof(float));
+    if (data == NULL) {
+        ma_decoder_uninit(&dec);
+        return 0;
+    }
+    ma_decoder_read_pcm_frames(&dec, data, frames, NULL);
+    *buffer = data;
+    if (sampleRate) *sampleRate = dec.outputSampleRate;
+    ma_decoder_uninit(&dec);
+    return (int)frames;
 }

--- a/src/c/drums.h
+++ b/src/c/drums.h
@@ -3,5 +3,9 @@
 
 void render_snare(float* out, int sampleRate, int samples);
 void render_kick(float* out, int sampleRate, int samples);
+void render_hihat(float* out, int sampleRate, int samples);
+void render_tom(float* out, int sampleRate, int samples);
+void render_clap(float* out, int sampleRate, int samples);
+int load_wav(const char* path, float** buffer, int* sampleRate);
 
 #endif

--- a/src/c/drums.h
+++ b/src/c/drums.h
@@ -1,11 +1,12 @@
 #ifndef DRUMS_H
 #define DRUMS_H
 
-void render_snare(float* out, int sampleRate, int samples);
-void render_kick(float* out, int sampleRate, int samples);
-void render_hihat(float* out, int sampleRate, int samples);
-void render_tom(float* out, int sampleRate, int samples);
-void render_clap(float* out, int sampleRate, int samples);
-int load_wav(const char* path, float** buffer, int* sampleRate);
+void render_snare(float *out, int sampleRate, int samples);
+void render_kick(float *out, int sampleRate, int samples);
+void render_hihat(float *out, int sampleRate, int samples);
+void render_tom(float *out, int sampleRate, int samples);
+void render_clap(float *out, int sampleRate, int samples);
+int load_wav(const char *path, float **buffer, int *sampleRate);
+const char *result_description(int code);
 
 #endif

--- a/src/go/internal/audio/clap.go
+++ b/src/go/internal/audio/clap.go
@@ -1,0 +1,18 @@
+//go:build !test && !js
+
+package audio
+
+import "time"
+
+// Clap renders multiple short noise bursts for a hand clap.
+type Clap struct{}
+
+// NewVoice generates a clap hit via the C renderer.
+func (Clap) NewVoice(bpm, sampleRate int) Voice {
+	spb := 60 / float64(bpm)
+	dur := time.Duration(spb * 0.25 * float64(time.Second))
+	samples := int(float64(sampleRate) * dur.Seconds())
+	buf := make([]float32, samples)
+	renderClap(buf, sampleRate, samples)
+	return &cVoice{buf: buf}
+}

--- a/src/go/internal/audio/drums_c.go
+++ b/src/go/internal/audio/drums_c.go
@@ -6,40 +6,90 @@ package audio
 #cgo CFLAGS: -I${SRCDIR}/../../../c
 #cgo LDFLAGS: -L${SRCDIR}/../../../../build -ldrums -lm
 #include "drums.h"
+#include <stdlib.h>
 */
 import "C"
-import "unsafe"
+import (
+	"errors"
+	"unsafe"
+)
 
 func renderSnare(buf []float32, sampleRate, samples int) {
-    if samples > len(buf) {
-        panic("renderSnare: samples exceeds buffer length")
-    }
-    if len(buf) == 0 || samples == 0 {
-        return
-    }
-    C.render_snare((*C.float)(unsafe.Pointer(&buf[0])), C.int(sampleRate), C.int(samples))
+	if samples > len(buf) {
+		panic("renderSnare: samples exceeds buffer length")
+	}
+	if len(buf) == 0 || samples == 0 {
+		return
+	}
+	C.render_snare((*C.float)(unsafe.Pointer(&buf[0])), C.int(sampleRate), C.int(samples))
 }
 
 func renderKick(buf []float32, sampleRate, samples int) {
-    if samples > len(buf) {
-        panic("renderKick: samples exceeds buffer length")
-    }
-    if len(buf) == 0 || samples == 0 {
-        return
-    }
-    C.render_kick((*C.float)(unsafe.Pointer(&buf[0])), C.int(sampleRate), C.int(samples))
+	if samples > len(buf) {
+		panic("renderKick: samples exceeds buffer length")
+	}
+	if len(buf) == 0 || samples == 0 {
+		return
+	}
+	C.render_kick((*C.float)(unsafe.Pointer(&buf[0])), C.int(sampleRate), C.int(samples))
+}
+
+func renderHiHat(buf []float32, sampleRate, samples int) {
+	if samples > len(buf) {
+		panic("renderHiHat: samples exceeds buffer length")
+	}
+	if len(buf) == 0 || samples == 0 {
+		return
+	}
+	C.render_hihat((*C.float)(unsafe.Pointer(&buf[0])), C.int(sampleRate), C.int(samples))
+}
+
+func renderTom(buf []float32, sampleRate, samples int) {
+	if samples > len(buf) {
+		panic("renderTom: samples exceeds buffer length")
+	}
+	if len(buf) == 0 || samples == 0 {
+		return
+	}
+	C.render_tom((*C.float)(unsafe.Pointer(&buf[0])), C.int(sampleRate), C.int(samples))
+}
+
+func renderClap(buf []float32, sampleRate, samples int) {
+	if samples > len(buf) {
+		panic("renderClap: samples exceeds buffer length")
+	}
+	if len(buf) == 0 || samples == 0 {
+		return
+	}
+	C.render_clap((*C.float)(unsafe.Pointer(&buf[0])), C.int(sampleRate), C.int(samples))
+}
+
+func loadWav(path string) ([]float32, int, error) {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	var ptr *C.float
+	var sr C.int
+	frames := C.load_wav(cpath, &ptr, &sr)
+	if frames <= 0 {
+		return nil, 0, errors.New("load_wav failed")
+	}
+	tmp := unsafe.Slice((*float32)(unsafe.Pointer(ptr)), int(frames))
+	buf := make([]float32, int(frames))
+	copy(buf, tmp)
+	C.free(unsafe.Pointer(ptr))
+	return buf, int(sr), nil
 }
 
 type cVoice struct {
-    buf []float32
-    i   int
+	buf []float32
+	i   int
 }
 
 func (v *cVoice) Sample() (float64, bool) {
-    if v.i >= len(v.buf) {
-        return 0, true
-    }
-    f := float64(v.buf[v.i])
-    v.i++
-    return f, false
+	if v.i >= len(v.buf) {
+		return 0, true
+	}
+	f := float64(v.buf[v.i])
+	v.i++
+	return f, false
 }

--- a/src/go/internal/audio/drums_c.go
+++ b/src/go/internal/audio/drums_c.go
@@ -11,6 +11,7 @@ package audio
 import "C"
 import (
 	"errors"
+	"fmt"
 	"unsafe"
 )
 
@@ -70,8 +71,12 @@ func loadWav(path string) ([]float32, int, error) {
 	var ptr *C.float
 	var sr C.int
 	frames := C.load_wav(cpath, &ptr, &sr)
-	if frames <= 0 {
-		return nil, 0, errors.New("load_wav failed")
+	if frames < 0 {
+		msg := C.GoString(C.result_description(C.int(frames)))
+		return nil, 0, fmt.Errorf("load_wav: %s", msg)
+	}
+	if frames == 0 {
+		return nil, 0, errors.New("load_wav: no frames")
 	}
 	tmp := unsafe.Slice((*float32)(unsafe.Pointer(ptr)), int(frames))
 	buf := make([]float32, int(frames))

--- a/src/go/internal/audio/drums_c.go
+++ b/src/go/internal/audio/drums_c.go
@@ -78,6 +78,9 @@ func loadWav(path string) ([]float32, int, error) {
 	if frames == 0 {
 		return nil, 0, errors.New("load_wav: no frames")
 	}
+	if ptr == nil {
+		return nil, 0, errors.New("load_wav: C returned nil pointer")
+	}
 	tmp := unsafe.Slice((*float32)(unsafe.Pointer(ptr)), int(frames))
 	buf := make([]float32, int(frames))
 	copy(buf, tmp)

--- a/src/go/internal/audio/engine.go
+++ b/src/go/internal/audio/engine.go
@@ -47,6 +47,9 @@ func Register(id string, inst Instrument) {
 func init() {
 	Register("snare", Snare{})
 	Register("kick", Kick{})
+	Register("hihat", HiHat{})
+	Register("tom", Tom{})
+	Register("clap", Clap{})
 }
 
 func initContext() {

--- a/src/go/internal/audio/engine_wasm.go
+++ b/src/go/internal/audio/engine_wasm.go
@@ -8,7 +8,11 @@ type Voice interface{}
 
 type Instrument interface{}
 
-func Register(id string, inst Instrument) {}
+var instruments = []string{"snare", "kick", "hihat", "tom", "clap"}
+
+func Register(id string, inst Instrument) {
+	instruments = append(instruments, id)
+}
 
 func Play(id string, when ...float64) {
 	js.Global().Call("playSound", id)
@@ -22,4 +26,4 @@ func Resume() {}
 
 func SetBPM(b int) {}
 
-func Instruments() []string { return []string{"snare", "kick"} }
+func Instruments() []string { return instruments }

--- a/src/go/internal/audio/engine_wasm.go
+++ b/src/go/internal/audio/engine_wasm.go
@@ -2,16 +2,24 @@
 
 package audio
 
-import "syscall/js"
+import (
+	"sync"
+	"syscall/js"
+)
 
 type Voice interface{}
 
 type Instrument interface{}
 
-var instruments = []string{"snare", "kick", "hihat", "tom", "clap"}
+var (
+	instruments   = []string{"snare", "kick", "hihat", "tom", "clap"}
+	instrumentsMu sync.RWMutex
+)
 
 func Register(id string, inst Instrument) {
+	instrumentsMu.Lock()
 	instruments = append(instruments, id)
+	instrumentsMu.Unlock()
 }
 
 func Play(id string, when ...float64) {
@@ -26,4 +34,9 @@ func Resume() {}
 
 func SetBPM(b int) {}
 
-func Instruments() []string { return instruments }
+func Instruments() []string {
+	instrumentsMu.RLock()
+	ids := append([]string(nil), instruments...)
+	instrumentsMu.RUnlock()
+	return ids
+}

--- a/src/go/internal/audio/hihat.go
+++ b/src/go/internal/audio/hihat.go
@@ -1,0 +1,19 @@
+//go:build !test && !js
+
+package audio
+
+import "time"
+
+// HiHat renders a short, bright noise burst.
+// It aims to mimic a closed hi-hat.
+type HiHat struct{}
+
+// NewVoice generates a hi-hat hit via the C renderer.
+func (HiHat) NewVoice(bpm, sampleRate int) Voice {
+	spb := 60 / float64(bpm)
+	dur := time.Duration(spb * 0.125 * float64(time.Second))
+	samples := int(float64(sampleRate) * dur.Seconds())
+	buf := make([]float32, samples)
+	renderHiHat(buf, sampleRate, samples)
+	return &cVoice{buf: buf}
+}

--- a/src/go/internal/audio/sample_desktop.go
+++ b/src/go/internal/audio/sample_desktop.go
@@ -1,0 +1,26 @@
+//go:build !test && !js
+
+package audio
+
+import "fmt"
+
+// Sample represents a preloaded PCM buffer.
+type Sample struct{ data []float32 }
+
+// NewVoice returns a voice that plays the sample once.
+func (s Sample) NewVoice(bpm, sampleRate int) Voice {
+	return &cVoice{buf: s.data}
+}
+
+// RegisterWAV decodes a .wav file and registers it as an instrument.
+func RegisterWAV(id, path string) error {
+	buf, sr, err := loadWav(path)
+	if err != nil {
+		return err
+	}
+	if sr != sampleRate {
+		return fmt.Errorf("expected %dHz wav, got %d", sampleRate, sr)
+	}
+	Register(id, Sample{data: buf})
+	return nil
+}

--- a/src/go/internal/audio/sample_desktop.go
+++ b/src/go/internal/audio/sample_desktop.go
@@ -16,7 +16,7 @@ func (s Sample) NewVoice(bpm, sampleRate int) Voice {
 func RegisterWAV(id, path string) error {
 	buf, sr, err := loadWav(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("load wav %s: %w", path, err)
 	}
 	if sr != sampleRate {
 		return fmt.Errorf("expected %dHz wav, got %d", sampleRate, sr)

--- a/src/go/internal/audio/sample_wasm.go
+++ b/src/go/internal/audio/sample_wasm.go
@@ -7,7 +7,9 @@ import "syscall/js"
 // RegisterWAV loads a wav file via JavaScript and registers it.
 func RegisterWAV(id, path string) error {
 	js.Global().Call("loadWav", id, path)
+	instrumentsMu.Lock()
 	instruments = append(instruments, id)
+	instrumentsMu.Unlock()
 	return nil
 }
 

--- a/src/go/internal/audio/sample_wasm.go
+++ b/src/go/internal/audio/sample_wasm.go
@@ -1,0 +1,15 @@
+//go:build js && wasm && !test
+
+package audio
+
+import "syscall/js"
+
+// RegisterWAV loads a wav file via JavaScript and registers it.
+func RegisterWAV(id, path string) error {
+	js.Global().Call("loadWav", id, path)
+	instruments = append(instruments, id)
+	return nil
+}
+
+// Sample type unused on wasm but kept for API parity.
+type Sample struct{}

--- a/src/go/internal/audio/stub.go
+++ b/src/go/internal/audio/stub.go
@@ -8,6 +8,8 @@ type Instrument interface{ NewVoice(int, int) Voice }
 
 func Register(id string, inst Instrument) {}
 
+func RegisterWAV(id, path string) error { return nil }
+
 // Play is a stub used during tests to avoid initializing audio devices.
 func Play(id string, when ...float64) {}
 
@@ -25,4 +27,4 @@ var SetBPMFunc = func(int) {}
 func SetBPM(bpm int) { SetBPMFunc(bpm) }
 
 // Instruments returns placeholder instrument IDs during tests.
-func Instruments() []string { return []string{"snare", "kick"} }
+func Instruments() []string { return []string{"snare", "kick", "hihat", "tom", "clap"} }

--- a/src/go/internal/audio/tom.go
+++ b/src/go/internal/audio/tom.go
@@ -1,0 +1,18 @@
+//go:build !test && !js
+
+package audio
+
+import "time"
+
+// Tom renders a pitched drum tone with a slight noise attack.
+type Tom struct{}
+
+// NewVoice generates a tom hit via the C renderer.
+func (Tom) NewVoice(bpm, sampleRate int) Voice {
+	spb := 60 / float64(bpm)
+	dur := time.Duration(spb * 0.5 * float64(time.Second))
+	samples := int(float64(sampleRate) * dur.Seconds())
+	buf := make([]float32, samples)
+	renderTom(buf, sampleRate, samples)
+	return &cVoice{buf: buf}
+}

--- a/src/go/internal/audio/wav_test.go
+++ b/src/go/internal/audio/wav_test.go
@@ -1,0 +1,99 @@
+//go:build !test
+
+package audio
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestWAV(path string) error {
+	const sampleRate = 44100
+	samples := sampleRate / 100 // 10ms
+	data := make([]int16, samples)
+	for i := range data {
+		data[i] = int16(math.Sin(2*math.Pi*float64(i)/float64(samples)) * 30000)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	dataSize := uint32(len(data) * 2)
+	if _, err := f.Write([]byte("RIFF")); err != nil {
+		return err
+	}
+	if err := binary.Write(f, binary.LittleEndian, 36+dataSize); err != nil {
+		return err
+	}
+	if _, err := f.Write([]byte("WAVEfmt ")); err != nil {
+		return err
+	}
+	if err := binary.Write(f, binary.LittleEndian, uint32(16)); err != nil {
+		return err
+	}
+	if err := binary.Write(f, binary.LittleEndian, uint16(1)); err != nil { // PCM
+		return err
+	}
+	if err := binary.Write(f, binary.LittleEndian, uint16(1)); err != nil { // mono
+		return err
+	}
+	if err := binary.Write(f, binary.LittleEndian, uint32(sampleRate)); err != nil {
+		return err
+	}
+	if err := binary.Write(f, binary.LittleEndian, uint32(sampleRate*2)); err != nil {
+		return err
+	}
+	if err := binary.Write(f, binary.LittleEndian, uint16(2)); err != nil { // block align
+		return err
+	}
+	if err := binary.Write(f, binary.LittleEndian, uint16(16)); err != nil { // bits per sample
+		return err
+	}
+	if _, err := f.Write([]byte("data")); err != nil {
+		return err
+	}
+	if err := binary.Write(f, binary.LittleEndian, dataSize); err != nil {
+		return err
+	}
+	for _, v := range data {
+		if err := binary.Write(f, binary.LittleEndian, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestRegisterWAVPlaysSample(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.wav")
+	if err := writeTestWAV(path); err != nil {
+		t.Fatalf("writeTestWAV: %v", err)
+	}
+	if err := RegisterWAV("testwav", path); err != nil {
+		t.Fatalf("RegisterWAV: %v", err)
+	}
+	instMu.RLock()
+	inst, ok := instruments["testwav"]
+	instMu.RUnlock()
+	if !ok {
+		t.Fatalf("instrument not registered")
+	}
+	m := &mixer{}
+	m.Schedule(inst.NewVoice(120, sampleRate), 0)
+	buf := make([]byte, sampleRate/100*2)
+	m.Read(buf)
+	nonZero := false
+	for _, b := range buf {
+		if b != 0 {
+			nonZero = true
+			break
+		}
+	}
+	if !nonZero {
+		t.Fatalf("expected non-zero audio output")
+	}
+}


### PR DESCRIPTION
## Summary
- Add hi-hat, tom, and clap synthesizers and enhance C drum library
- Allow loading external WAV samples and register new instruments in Go and JS
- Export new functions for WebAssembly and expose JS helpers to play or load sounds

## Testing
- `make wasm`
- `make test` *(fails: missing Playwright dependencies)*
- `make test-real` *(fails: missing X11 headers)*
- `xvfb-run -a timeout 5 make run RUN_ARGS=-demo` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898223a53788331990ac0ea7a6d6b41