### PR TITLE
Decouple game engine from UI and revamped UI with seekable timeline

### DIFF
--- a/src/go/core/engine/engine.go
+++ b/src/go/core/engine/engine.go
@@ -1,0 +1,80 @@
+package engine
+
+import (
+	"context"
+	"time"
+
+	"github.com/ingyamilmolinar/tunkul/core/beat"
+	"github.com/ingyamilmolinar/tunkul/core/model"
+	game_log "github.com/ingyamilmolinar/tunkul/internal/log"
+)
+
+// Event represents a tick from the game engine.
+type Event struct {
+	Step int
+}
+
+// Engine encapsulates the core game logic and runs it on its own goroutine.
+type Engine struct {
+	Graph  *model.Graph
+	sched  *beat.Scheduler
+	Events chan Event
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// New creates a new Engine instance and starts its run loop.
+func New(logger *game_log.Logger) *Engine {
+	graph := model.NewGraph(logger)
+	sched := beat.NewScheduler()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	e := &Engine{
+		Graph:  graph,
+		sched:  sched,
+		Events: make(chan Event, 16),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	sched.OnTick = func(step int) {
+		select {
+		case e.Events <- Event{Step: step}:
+		default:
+		}
+	}
+
+	go e.run()
+	return e
+}
+
+func (e *Engine) run() {
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			e.sched.Tick()
+		case <-e.ctx.Done():
+			return
+		}
+	}
+}
+
+// Start begins the scheduler.
+func (e *Engine) Start() { e.sched.Start() }
+
+// Stop stops the scheduler.
+func (e *Engine) Stop() { e.sched.Stop() }
+
+// SetBPM updates the scheduler BPM.
+func (e *Engine) SetBPM(bpm int) { e.sched.SetBPM(bpm) }
+
+// BPM returns the current scheduler BPM.
+func (e *Engine) BPM() int { return e.sched.BPM }
+
+// Close terminates the engine goroutine.
+func (e *Engine) Close() { e.cancel() }
+
+// BeatLength exposes the scheduler's beat length.
+func (e *Engine) BeatLength() int { return e.sched.BeatLength }

--- a/src/go/core/engine/engine.go
+++ b/src/go/core/engine/engine.go
@@ -14,6 +14,8 @@ type Event struct {
 	Step int
 }
 
+const tickInterval = 16 * time.Millisecond
+
 // Engine encapsulates the core game logic and runs it on its own goroutine.
 type Engine struct {
 	Graph  *model.Graph
@@ -49,7 +51,7 @@ func New(logger *game_log.Logger) *Engine {
 }
 
 func (e *Engine) run() {
-	ticker := time.NewTicker(time.Millisecond)
+	ticker := time.NewTicker(tickInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/src/go/internal/ui/bpm.go
+++ b/src/go/internal/ui/bpm.go
@@ -1,0 +1,3 @@
+package ui
+
+const maxBPM = 1000

--- a/src/go/internal/ui/components.go
+++ b/src/go/internal/ui/components.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
+// pixel helper is defined in widgets.go and reused here.
+
 // fadeColor returns c with its alpha scaled by t (0..1).
 func fadeColor(c color.Color, t float64) color.Color {
 	r, g, b, a := c.RGBA()

--- a/src/go/internal/ui/components.go
+++ b/src/go/internal/ui/components.go
@@ -50,11 +50,20 @@ type SignalStyle struct {
 // Draw renders the signal at world coordinates with the given camera transform.
 func (s SignalStyle) Draw(dst *ebiten.Image, x, y float64, cam *ebiten.GeoM) {
 	size := float64(s.Radius) * 2
+	// Outer glow
 	var op ebiten.DrawImageOptions
-	op.GeoM.Scale(size, size)
-	op.GeoM.Translate(x-float64(s.Radius), y-float64(s.Radius))
+	glowSize := size * 1.5
+	op.GeoM.Scale(glowSize, glowSize)
+	op.GeoM.Translate(x-glowSize/2, y-glowSize/2)
 	op.GeoM.Concat(*cam)
-	dst.DrawImage(pixel(s.Color), &op)
+	dst.DrawImage(pixel(fadeColor(s.Color, 0.3)), &op)
+
+	// Inner core
+	var op2 ebiten.DrawImageOptions
+	op2.GeoM.Scale(size, size)
+	op2.GeoM.Translate(x-size/2, y-size/2)
+	op2.GeoM.Concat(*cam)
+	dst.DrawImage(pixel(s.Color), &op2)
 }
 
 // EdgeStyle draws directional edges between nodes.

--- a/src/go/internal/ui/components.go
+++ b/src/go/internal/ui/components.go
@@ -92,17 +92,29 @@ func (s EdgeStyle) DrawProgress(dst *ebiten.Image, x1, y1, x2, y2 float64, cam *
 	col := fadeColor(s.Color, t)
 	ex := x1 + (x2-x1)*t
 	ey := y1 + (y2-y1)*t
-	DrawLineCam(dst, x1, y1, ex, ey, cam, col, s.Thickness)
-	if t < 1 {
-		return
-	}
-	angle := math.Atan2(y2-y1, x2-x1)
-	leftX := x2 - s.ArrowSize*math.Cos(angle-math.Pi/6)
-	leftY := y2 - s.ArrowSize*math.Sin(angle-math.Pi/6)
-	rightX := x2 - s.ArrowSize*math.Cos(angle+math.Pi/6)
-	rightY := y2 - s.ArrowSize*math.Sin(angle+math.Pi/6)
-	DrawLineCam(dst, x2, y2, leftX, leftY, cam, col, s.Thickness)
-	DrawLineCam(dst, x2, y2, rightX, rightY, cam, col, s.Thickness)
+        DrawLineCam(dst, x1, y1, ex, ey, cam, col, s.Thickness)
+        if t < 1 {
+                return
+        }
+        angle := math.Atan2(y2-y1, x2-x1)
+
+        // Arrowhead at the end of the edge
+        leftX := x2 - s.ArrowSize*math.Cos(angle-math.Pi/6)
+        leftY := y2 - s.ArrowSize*math.Sin(angle-math.Pi/6)
+        rightX := x2 - s.ArrowSize*math.Cos(angle+math.Pi/6)
+        rightY := y2 - s.ArrowSize*math.Sin(angle+math.Pi/6)
+        DrawLineCam(dst, x2, y2, leftX, leftY, cam, col, s.Thickness)
+        DrawLineCam(dst, x2, y2, rightX, rightY, cam, col, s.Thickness)
+
+        // Permanent direction marker at midpoint
+        mx := (x1 + x2) / 2
+        my := (y1 + y2) / 2
+        midLeftX := mx - s.ArrowSize*math.Cos(angle-math.Pi/6)
+        midLeftY := my - s.ArrowSize*math.Sin(angle-math.Pi/6)
+        midRightX := mx - s.ArrowSize*math.Cos(angle+math.Pi/6)
+        midRightY := my - s.ArrowSize*math.Sin(angle+math.Pi/6)
+        DrawLineCam(dst, mx, my, midLeftX, midLeftY, cam, col, s.Thickness)
+        DrawLineCam(dst, mx, my, midRightX, midRightY, cam, col, s.Thickness)
 }
 
 // ButtonStyle describes rectangular button visuals.

--- a/src/go/internal/ui/components.go
+++ b/src/go/internal/ui/components.go
@@ -1,0 +1,115 @@
+package ui
+
+import (
+	"image"
+	"image/color"
+	"math"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// NodeStyle defines visual appearance for graph nodes.
+type NodeStyle struct {
+	Radius float32
+	Fill   color.Color
+	Border color.Color
+}
+
+// Draw renders a node at world coordinates using the provided camera matrix.
+func (s NodeStyle) Draw(dst *ebiten.Image, x, y float64, cam *ebiten.GeoM) {
+	size := float64(s.Radius) * 2
+	var op ebiten.DrawImageOptions
+	op.GeoM.Scale(size, size)
+	op.GeoM.Translate(x-float64(s.Radius), y-float64(s.Radius))
+	op.GeoM.Concat(*cam)
+	dst.DrawImage(pixel(s.Fill), &op)
+	DrawLineCam(dst, x-float64(s.Radius), y-float64(s.Radius), x+float64(s.Radius), y-float64(s.Radius), cam, s.Border, 1)
+	DrawLineCam(dst, x+float64(s.Radius), y-float64(s.Radius), x+float64(s.Radius), y+float64(s.Radius), cam, s.Border, 1)
+	DrawLineCam(dst, x+float64(s.Radius), y+float64(s.Radius), x-float64(s.Radius), y+float64(s.Radius), cam, s.Border, 1)
+	DrawLineCam(dst, x-float64(s.Radius), y+float64(s.Radius), x-float64(s.Radius), y-float64(s.Radius), cam, s.Border, 1)
+}
+
+// SignalStyle defines the appearance of travelling pulses between nodes.
+type SignalStyle struct {
+	Radius float32
+	Color  color.Color
+}
+
+// Draw renders the signal at world coordinates with the given camera transform.
+func (s SignalStyle) Draw(dst *ebiten.Image, x, y float64, cam *ebiten.GeoM) {
+	size := float64(s.Radius) * 2
+	var op ebiten.DrawImageOptions
+	op.GeoM.Scale(size, size)
+	op.GeoM.Translate(x-float64(s.Radius), y-float64(s.Radius))
+	op.GeoM.Concat(*cam)
+	dst.DrawImage(pixel(s.Color), &op)
+}
+
+// EdgeStyle draws directional edges between nodes.
+type EdgeStyle struct {
+	Color     color.Color
+	Thickness float64
+	ArrowSize float64
+}
+
+// Draw renders a directed edge from (x1,y1) to (x2,y2) using cam.
+func (s EdgeStyle) Draw(dst *ebiten.Image, x1, y1, x2, y2 float64, cam *ebiten.GeoM) {
+	DrawLineCam(dst, x1, y1, x2, y2, cam, s.Color, s.Thickness)
+	angle := math.Atan2(y2-y1, x2-x1)
+	leftX := x2 - s.ArrowSize*math.Cos(angle-math.Pi/6)
+	leftY := y2 - s.ArrowSize*math.Sin(angle-math.Pi/6)
+	rightX := x2 - s.ArrowSize*math.Cos(angle+math.Pi/6)
+	rightY := y2 - s.ArrowSize*math.Sin(angle+math.Pi/6)
+	DrawLineCam(dst, x2, y2, leftX, leftY, cam, s.Color, s.Thickness)
+	DrawLineCam(dst, x2, y2, rightX, rightY, cam, s.Color, s.Thickness)
+}
+
+// ButtonStyle describes rectangular button visuals.
+type ButtonStyle struct {
+	Fill   color.Color
+	Border color.Color
+}
+
+// Draw renders the button rectangle using the global drawButton primitive.
+func (s ButtonStyle) Draw(dst *ebiten.Image, r image.Rectangle, pressed bool) {
+	drawButton(dst, r, s.Fill, s.Border, pressed)
+}
+
+// TextInputStyle styles a text input box.
+type TextInputStyle struct {
+	Fill   color.Color
+	Border color.Color
+}
+
+// Draw renders the text box using drawButton for consistency.
+func (s TextInputStyle) Draw(dst *ebiten.Image, r image.Rectangle, focused bool) {
+	drawButton(dst, r, s.Fill, s.Border, focused)
+}
+
+// DrumCellStyle styles individual drum machine cells.
+type DrumCellStyle struct {
+	On        color.Color
+	Off       color.Color
+	Highlight color.Color
+	Border    color.Color
+}
+
+// Draw renders a drum cell considering its state. onCol overrides the default On color.
+func (s DrumCellStyle) Draw(dst *ebiten.Image, r image.Rectangle, on, highlighted bool, onCol color.Color) {
+	fill := s.Off
+	if on {
+		if onCol != nil {
+			fill = onCol
+		} else {
+			fill = s.On
+		}
+	}
+	if highlighted {
+		fill = s.Highlight
+	}
+	drawRect(dst, r, fill, true)
+	drawRect(dst, r, s.Border, false)
+}
+
+// DrumRowStyle is reserved for future customisation of entire rows.
+type DrumRowStyle struct{}

--- a/src/go/internal/ui/components.go
+++ b/src/go/internal/ui/components.go
@@ -92,29 +92,29 @@ func (s EdgeStyle) DrawProgress(dst *ebiten.Image, x1, y1, x2, y2 float64, cam *
 	col := fadeColor(s.Color, t)
 	ex := x1 + (x2-x1)*t
 	ey := y1 + (y2-y1)*t
-        DrawLineCam(dst, x1, y1, ex, ey, cam, col, s.Thickness)
-        if t < 1 {
-                return
-        }
-        angle := math.Atan2(y2-y1, x2-x1)
+	DrawLineCam(dst, x1, y1, ex, ey, cam, col, s.Thickness)
+	if t < 1 {
+		return
+	}
+	angle := math.Atan2(y2-y1, x2-x1)
 
-        // Arrowhead at the end of the edge
-        leftX := x2 - s.ArrowSize*math.Cos(angle-math.Pi/6)
-        leftY := y2 - s.ArrowSize*math.Sin(angle-math.Pi/6)
-        rightX := x2 - s.ArrowSize*math.Cos(angle+math.Pi/6)
-        rightY := y2 - s.ArrowSize*math.Sin(angle+math.Pi/6)
-        DrawLineCam(dst, x2, y2, leftX, leftY, cam, col, s.Thickness)
-        DrawLineCam(dst, x2, y2, rightX, rightY, cam, col, s.Thickness)
+	// Arrowhead at the end of the edge
+	leftX := x2 - s.ArrowSize*math.Cos(angle-math.Pi/6)
+	leftY := y2 - s.ArrowSize*math.Sin(angle-math.Pi/6)
+	rightX := x2 - s.ArrowSize*math.Cos(angle+math.Pi/6)
+	rightY := y2 - s.ArrowSize*math.Sin(angle+math.Pi/6)
+	DrawLineCam(dst, x2, y2, leftX, leftY, cam, col, s.Thickness)
+	DrawLineCam(dst, x2, y2, rightX, rightY, cam, col, s.Thickness)
 
-        // Permanent direction marker at midpoint
-        mx := (x1 + x2) / 2
-        my := (y1 + y2) / 2
-        midLeftX := mx - s.ArrowSize*math.Cos(angle-math.Pi/6)
-        midLeftY := my - s.ArrowSize*math.Sin(angle-math.Pi/6)
-        midRightX := mx - s.ArrowSize*math.Cos(angle+math.Pi/6)
-        midRightY := my - s.ArrowSize*math.Sin(angle+math.Pi/6)
-        DrawLineCam(dst, mx, my, midLeftX, midLeftY, cam, col, s.Thickness)
-        DrawLineCam(dst, mx, my, midRightX, midRightY, cam, col, s.Thickness)
+	// Permanent direction marker at midpoint
+	mx := (x1 + x2) / 2
+	my := (y1 + y2) / 2
+	midLeftX := mx - s.ArrowSize*math.Cos(angle-math.Pi/6)
+	midLeftY := my - s.ArrowSize*math.Sin(angle-math.Pi/6)
+	midRightX := mx - s.ArrowSize*math.Cos(angle+math.Pi/6)
+	midRightY := my - s.ArrowSize*math.Sin(angle+math.Pi/6)
+	DrawLineCam(dst, mx, my, midLeftX, midLeftY, cam, col, s.Thickness)
+	DrawLineCam(dst, mx, my, midRightX, midRightY, cam, col, s.Thickness)
 }
 
 // ButtonStyle describes rectangular button visuals.

--- a/src/go/internal/ui/demo.go
+++ b/src/go/internal/ui/demo.go
@@ -14,7 +14,7 @@ func (g *Game) RunDemo() {
 	g.addEdge(a, b)
 	g.playing = true
 	g.engine.Start()
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 	go func() {
 		time.Sleep(2 * time.Second)
 		g.logger.Infof("[DEMO] Finished demo run")

--- a/src/go/internal/ui/demo.go
+++ b/src/go/internal/ui/demo.go
@@ -13,7 +13,7 @@ func (g *Game) RunDemo() {
 	b := g.tryAddNode(5, 1, model.NodeTypeRegular)
 	g.addEdge(a, b)
 	g.playing = true
-	g.sched.Start()
+	g.engine.Start()
 	g.spawnPulse()
 	go func() {
 		time.Sleep(2 * time.Second)

--- a/src/go/internal/ui/drawing.go
+++ b/src/go/internal/ui/drawing.go
@@ -27,5 +27,35 @@ var drawButton = func(dst *ebiten.Image, r image.Rectangle, fill, border color.C
 		}
 	}
 	vector.DrawFilledRect(dst, float32(r.Min.X), float32(r.Min.Y), float32(r.Dx()), float32(r.Dy()), fc, false)
+
+	// 3D bevel effect: lighter top/left, darker bottom/right.
+	lx0, ly0 := float32(r.Min.X), float32(r.Min.Y)
+	lx1, ly1 := float32(r.Max.X-1), float32(r.Max.Y-1)
+	light := adjustColor(fc, 40)
+	dark := adjustColor(fc, -40)
+	vector.DrawFilledRect(dst, lx0, ly0, lx1-lx0+1, 1, light, false)
+	vector.DrawFilledRect(dst, lx0, ly0, 1, ly1-ly0+1, light, false)
+	vector.DrawFilledRect(dst, lx0, ly1, lx1-lx0+1, 1, dark, false)
+	vector.DrawFilledRect(dst, lx1, ly0, 1, ly1-ly0+1, dark, false)
+
 	vector.StrokeRect(dst, float32(r.Min.X), float32(r.Min.Y), float32(r.Dx()), float32(r.Dy()), 1, border, false)
+}
+
+// adjustColor lightens or darkens a color by delta (-255..255).
+func adjustColor(c color.Color, delta int) color.Color {
+	r, g, b, a := c.RGBA()
+	rr := clamp(int(r>>8)+delta, 0, 255)
+	gg := clamp(int(g>>8)+delta, 0, 255)
+	bb := clamp(int(b>>8)+delta, 0, 255)
+	return color.RGBA{uint8(rr), uint8(gg), uint8(bb), uint8(a >> 8)}
+}
+
+func clamp(v, min, max int) int {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
 }

--- a/src/go/internal/ui/drumview.go
+++ b/src/go/internal/ui/drumview.go
@@ -111,9 +111,7 @@ type DrumView struct {
 	startOffset   int
 	offsetChanged bool
 
-	scrubbing     bool
-	seekBeat      int
-	seekRequested bool
+	scrubbing bool
 }
 
 /* ─── geometry helpers ─────────────────────────────────────── */
@@ -243,12 +241,6 @@ func (dv *DrumView) OffsetChanged() bool {
 	}
 	return false
 }
-
-func (dv *DrumView) SeekRequested() bool { return dv.seekRequested }
-
-func (dv *DrumView) SeekBeat() int { return dv.seekBeat }
-
-func (dv *DrumView) ClearSeek() { dv.seekRequested = false }
 
 func (dv *DrumView) SetLength(length int) {
 	if length < 1 {
@@ -523,10 +515,8 @@ func (dv *DrumView) Update() {
 			dv.Offset = beat
 			dv.offsetChanged = true
 		}
-		dv.seekBeat = beat
 		if !left {
 			dv.scrubbing = false
-			dv.seekRequested = true
 		}
 	}
 

--- a/src/go/internal/ui/drumview.go
+++ b/src/go/internal/ui/drumview.go
@@ -459,15 +459,15 @@ func (dv *DrumView) Draw(dst *ebiten.Image, highlightedBeats map[int]int64, fram
 	op.GeoM.Translate(float64(dv.Bounds.Min.X), float64(dv.Bounds.Min.Y))
 	dst.DrawImage(dv.bg(dv.Bounds.Dx(), dv.Bounds.Dy()), op)
 
-	drawButton(dst, dv.playBtn, colPlayButton, colButtonBorder, dv.playPressed)
-	drawButton(dst, dv.stopBtn, colStopButton, colButtonBorder, dv.stopPressed)
-	drawButton(dst, dv.bpmDecBtn, colLenDec, colButtonBorder, dv.bpmDecPressed)
-	drawButton(dst, dv.bpmBox, colBPMBox, colButtonBorder, dv.focusBPM)
-	drawButton(dst, dv.bpmIncBtn, colLenInc, colButtonBorder, dv.bpmIncPressed)
-	drawButton(dst, dv.lenDecBtn, colLenDec, colButtonBorder, dv.lenDecPressed)
-	drawButton(dst, dv.lenIncBtn, colLenInc, colButtonBorder, dv.lenIncPressed)
-	drawButton(dst, dv.instBtn, colBPMBox, colButtonBorder, false)
-	drawButton(dst, dv.uploadBtn, colBPMBox, colButtonBorder, false)
+	PlayButtonStyle.Draw(dst, dv.playBtn, dv.playPressed)
+	StopButtonStyle.Draw(dst, dv.stopBtn, dv.stopPressed)
+	BPMDecStyle.Draw(dst, dv.bpmDecBtn, dv.bpmDecPressed)
+	BPMBoxStyle.Draw(dst, dv.bpmBox, dv.focusBPM)
+	BPMIncStyle.Draw(dst, dv.bpmIncBtn, dv.bpmIncPressed)
+	LenDecStyle.Draw(dst, dv.lenDecBtn, dv.lenDecPressed)
+	LenIncStyle.Draw(dst, dv.lenIncBtn, dv.lenIncPressed)
+	InstButtonStyle.Draw(dst, dv.instBtn, false)
+	UploadBtnStyle.Draw(dst, dv.uploadBtn, false)
 	ebitenutil.DebugPrintAt(dst, "▶", dv.playBtn.Min.X+30, dv.playBtn.Min.Y+18)
 	ebitenutil.DebugPrintAt(dst, "■", dv.stopBtn.Min.X+30, dv.stopBtn.Min.Y+18)
 	ebitenutil.DebugPrintAt(dst, "-", dv.bpmDecBtn.Min.X+15, dv.bpmDecBtn.Min.Y+18)
@@ -498,15 +498,7 @@ func (dv *DrumView) Draw(dst *ebiten.Image, highlightedBeats map[int]int64, fram
 				}
 			}
 
-			var fill color.Color = colStepOff
-			if step {
-				fill = r.Color
-			}
-			if highlighted {
-				fill = colHighlight
-			}
-			drawRect(dst, rect, fill, true)
-			drawRect(dst, rect, colStepBorder, false)
+			DrumCellUI.Draw(dst, rect, step && isRegularNode, highlighted, r.Color)
 		}
 	}
 

--- a/src/go/internal/ui/drumview.go
+++ b/src/go/internal/ui/drumview.go
@@ -561,9 +561,7 @@ func (dv *DrumView) Update() {
 	}
 	if dv.bpmDecPressed {
 		dv.SetBPM(dv.bpm - 1)
-		if dv.bpm > 1 {
-			dv.logger.Infof("[DRUMVIEW] BPM decreased to: %d", dv.bpm)
-		}
+		dv.logger.Infof("[DRUMVIEW] BPM decreased to: %d", dv.bpm)
 		dv.bpmDecPressed = false
 	}
 

--- a/src/go/internal/ui/drumview_test.go
+++ b/src/go/internal/ui/drumview_test.go
@@ -421,3 +421,24 @@ func TestDrumViewDrawHighlightsInvisibleCells(t *testing.T) {
 		t.Fatalf("expected 1 highlight draw, got %d", highlightCount)
 	}
 }
+
+func TestDrumViewSetBPMClamp(t *testing.T) {
+	logger := game_log.New(io.Discard, game_log.LevelError)
+	graph := model.NewGraph(logger)
+	dv := NewDrumView(image.Rect(0, 0, 100, 100), graph, logger)
+	dv.SetBPM(maxBPM + 10)
+	if dv.bpm != maxBPM {
+		t.Fatalf("expected BPM %d, got %d", maxBPM, dv.bpm)
+	}
+	if dv.bpmErrorAnim == 0 {
+		t.Errorf("expected error animation on high bpm")
+	}
+	dv.bpmErrorAnim = 0
+	dv.SetBPM(0)
+	if dv.bpm != 1 {
+		t.Fatalf("expected BPM 1, got %d", dv.bpm)
+	}
+	if dv.bpmErrorAnim == 0 {
+		t.Errorf("expected error animation on low bpm")
+	}
+}

--- a/src/go/internal/ui/drumview_test.go
+++ b/src/go/internal/ui/drumview_test.go
@@ -81,7 +81,7 @@ func TestDrumViewWheelAdjustsLength(t *testing.T) {
 	dv := NewDrumView(image.Rect(0, 0, 800, 100), graph, logger)
 
 	wheelVal := 1.0
-	cursor := func() (int, int) { return dv.Bounds.Min.X + dv.labelW + 500, dv.Bounds.Min.Y + 5 }
+	cursor := func() (int, int) { return dv.Bounds.Min.X + dv.labelW + 500, dv.Bounds.Min.Y + timelineHeight + 5 }
 	restore := SetInputForTest(cursor,
 		func(ebiten.MouseButton) bool { return false },
 		func(ebiten.Key) bool { return false },

--- a/src/go/internal/ui/drumview_test.go
+++ b/src/go/internal/ui/drumview_test.go
@@ -321,7 +321,7 @@ func TestDrumViewDrawHighlightsInvisibleCells(t *testing.T) {
 
 	var highlightCount int
 	for _, call := range calls {
-		if clr, ok := call.c.(color.RGBA); ok && clr.R == 255 && clr.G == 255 && clr.B == 0 && clr.A == 255 {
+		if clr, ok := call.c.(color.RGBA); ok && clr == colHighlight {
 			highlightCount++
 		}
 	}

--- a/src/go/internal/ui/drumview_test.go
+++ b/src/go/internal/ui/drumview_test.go
@@ -229,7 +229,7 @@ func TestDrumViewLoopHighlighting(t *testing.T) {
 	// Simulate starting playback
 	game.playing = true
 	game.updateBeatInfos() // Call updateBeatInfos after drum is set
-	game.spawnPulse()
+	game.spawnPulseFrom(0)
 
 	// Run for a few cycles to test loop highlighting
 	for i := 0; i < 20; i++ { // Simulate 20 frames
@@ -284,7 +284,7 @@ func TestDrumViewButtonsDrawn(t *testing.T) {
 	}
 	defer func() { drawButton = orig }()
 
-	dv.Draw(ebiten.NewImage(400, 100), map[int]int64{}, 0, nil)
+	dv.Draw(ebiten.NewImage(400, 100), map[int]int64{}, 0, nil, 0)
 	if count != 9 {
 		t.Fatalf("expected 9 buttons drawn, got %d", count)
 	}
@@ -317,7 +317,7 @@ func TestDrumViewDrawHighlightsInvisibleCells(t *testing.T) {
 	defer func() { drawRect = orig }()
 
 	highlighted := map[int]int64{1: 1}
-	dv.Draw(ebiten.NewImage(300, 50), highlighted, 0, game.beatInfos)
+	dv.Draw(ebiten.NewImage(300, 50), highlighted, 0, game.beatInfos, 0)
 
 	var highlightCount int
 	for _, call := range calls {

--- a/src/go/internal/ui/drumview_test.go
+++ b/src/go/internal/ui/drumview_test.go
@@ -118,6 +118,33 @@ func TestDrumViewLengthMinMax(t *testing.T) {
 	}
 }
 
+func TestTimelineInfo(t *testing.T) {
+	logger := game_log.New(io.Discard, game_log.LevelDebug)
+	graph := model.NewGraph(logger)
+	dv := NewDrumView(image.Rect(0, 0, 100, 100), graph, logger)
+	dv.bpm = 120
+	info := dv.timelineInfo(4)
+	expected := "00:02.000/00:04.000 | Beats 1-8/8"
+	if info != expected {
+		t.Fatalf("expected %q got %q", expected, info)
+	}
+}
+
+func TestTimelineLayout(t *testing.T) {
+	logger := game_log.New(io.Discard, game_log.LevelDebug)
+	graph := model.NewGraph(logger)
+	dv := NewDrumView(image.Rect(0, 0, 800, 200), graph, logger)
+	dv.recalcButtons()
+	textY := dv.Bounds.Min.Y + 5
+	if textY >= dv.timelineRect.Min.Y {
+		t.Fatalf("info text overlaps timeline bar")
+	}
+	rowStart := dv.Bounds.Min.Y + timelineHeight
+	if dv.timelineRect.Max.Y >= rowStart {
+		t.Fatalf("timeline bar overlaps drum rows")
+	}
+}
+
 func TestDrumViewUpdatesGraphBeatLength(t *testing.T) {
 	logger := game_log.New(os.Stdout, game_log.LevelDebug)
 	graph := model.NewGraph(logger)

--- a/src/go/internal/ui/game.go
+++ b/src/go/internal/ui/game.go
@@ -675,8 +675,6 @@ func (g *Game) drawGridPane(screen *ebiten.Image) {
 	cam.Scale(camScale, camScale)
 	cam.Translate(offX, offY+float64(topOffset))
 
-	frame := (g.frame / int64(6)) % int64(len(NodeFrames))
-
 	// grid lattice computed in world coordinates then transformed
 	minX, maxX, minY, maxY := visibleWorldRect(g.cam, g.winW, g.split.Y)
 	startI := int(math.Floor(minX / GridStep))
@@ -696,15 +694,13 @@ func (g *Game) drawGridPane(screen *ebiten.Image) {
 
 	// edges
 	for _, e := range g.edges {
-		DrawLineCam(screen, e.A.X, e.A.Y, e.B.X, e.B.Y,
-			&cam, color.White, 2)
+		EdgeUI.Draw(screen, e.A.X, e.A.Y, e.B.X, e.B.Y, &cam)
 	}
 
 	// link preview
 	if g.linkDrag.active {
-		DrawLineCam(screen, g.linkDrag.from.X, g.linkDrag.from.Y,
-			g.linkDrag.toX, g.linkDrag.toY,
-			&cam, color.RGBA{200, 200, 200, 255}, 2)
+		EdgeUI.Draw(screen, g.linkDrag.from.X, g.linkDrag.from.Y,
+			g.linkDrag.toX, g.linkDrag.toY, &cam)
 	}
 
 	// nodes
@@ -713,11 +709,7 @@ func (g *Game) drawGridPane(screen *ebiten.Image) {
 		if !ok || nodeInfo.Type != model.NodeTypeRegular {
 			continue
 		}
-		op := &ebiten.DrawImageOptions{}
-		op.GeoM.Translate(-float64(NodeSpriteSize)/2, -float64(NodeSpriteSize)/2)
-		op.GeoM.Translate(n.X, n.Y)
-		op.GeoM.Concat(cam)
-		screen.DrawImage(NodeFrames[frame], op)
+		NodeUI.Draw(screen, n.X, n.Y, &cam)
 		if n.Start {
 			x1, y1, x2, y2 := g.nodeScreenRect(n)
 			var id ebiten.GeoM
@@ -734,10 +726,7 @@ func (g *Game) drawGridPane(screen *ebiten.Image) {
 		p := g.activePulse
 		px := p.x1 + (p.x2-p.x1)*p.t
 		py := p.y1 + (p.y2-p.y1)*p.t
-		op := &ebiten.DrawImageOptions{}
-		op.GeoM.Translate(px-8, py-8)
-		op.GeoM.Concat(cam)
-		screen.DrawImage(SignalDot, op)
+		SignalUI.Draw(screen, px, py, &cam)
 		g.renderedPulsesCount = 1
 	}
 

--- a/src/go/internal/ui/game.go
+++ b/src/go/internal/ui/game.go
@@ -643,10 +643,6 @@ eventsDone:
 	prevLen := g.drum.Length
 	prevBPM := g.bpm
 	g.drum.Update()
-	if g.drum.SeekRequested() {
-		g.Seek(g.drum.SeekBeat())
-		g.drum.ClearSeek()
-	}
 	if g.drum.OffsetChanged() {
 		g.refreshDrumRow()
 	}

--- a/src/go/internal/ui/game_test.go
+++ b/src/go/internal/ui/game_test.go
@@ -311,7 +311,7 @@ func TestBPMButtonsAdjustSpeed(t *testing.T) {
 
 	g.playing = true
 	g.engine.Start()
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 	if g.activePulse == nil {
 		t.Fatalf("no pulse spawned")
 	}
@@ -404,7 +404,7 @@ func TestPulseAnimationProgress(t *testing.T) {
 
 	// Manually set playing to true and call spawnPulse to create the pulse
 	g.playing = true
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 
 	// The pulse should be active now
 	if g.activePulse == nil {
@@ -442,7 +442,7 @@ func TestPlaySoundOnRegularNodesOnly(t *testing.T) {
 	defer func() { playSound = orig }()
 
 	g.playing = true
-	g.spawnPulse() // highlights start node
+	g.spawnPulseFrom(0) // highlights start node
 
 	if len(plays) != 1 {
 		t.Fatalf("expected 1 sample for start node, got %d", len(plays))
@@ -524,7 +524,7 @@ func TestAudioLoopConsistency(t *testing.T) {
 	defer func() { playSound = orig }()
 
 	g.playing = true
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 
 	for i := 0; i < 8; i++ {
 		g.activePulse.t = 1
@@ -938,7 +938,7 @@ func TestHighlightEmptyCells(t *testing.T) {
 
 	g.playing = true
 	g.engine.Start()
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 
 	if _, ok := g.highlightedBeats[0]; !ok {
 		t.Errorf("Tick 0: Beat at index 0 should be highlighted")
@@ -1014,7 +1014,7 @@ func TestPulseTraversalIgnoresDrumLength(t *testing.T) {
 	g.drum.Rows[0].Steps = g.drum.Rows[0].Steps[:g.drum.Length]
 
 	g.playing = true
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 
 	if g.activePulse == nil || g.activePulse.toBeatInfo.NodeID != n1.ID {
 		t.Fatalf("expected pulse heading to second node")
@@ -1207,7 +1207,7 @@ func TestPulseTraversalBeyondDrumView(t *testing.T) {
 	g.updateBeatInfos()
 
 	g.playing = true
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 	if g.activePulse == nil {
 		t.Fatalf("expected active pulse")
 	}
@@ -1282,7 +1282,7 @@ func TestSignalTraversalInLoop(t *testing.T) {
 	}
 
 	g.playing = true
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 
 	if g.activePulse == nil {
 		t.Fatalf("Expected active pulse after spawning")
@@ -1359,7 +1359,7 @@ func TestLoopExpansionAndHighlighting(t *testing.T) {
 	}
 
 	// now simulate pulse highlighting across two laps
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 	// sequence of highlighted beat indices expected for first 12 advancements
 	expected := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 	got := make([]int, len(expected))
@@ -1410,7 +1410,7 @@ func TestBPMChangeDuringLoopKeepsForwardProgress(t *testing.T) {
 	g.updateBeatInfos()
 
 	g.playing = true
-	g.spawnPulse()
+	g.spawnPulseFrom(0)
 	if g.activePulse == nil {
 		t.Fatalf("expected active pulse")
 	}

--- a/src/go/internal/ui/game_test.go
+++ b/src/go/internal/ui/game_test.go
@@ -93,7 +93,7 @@ func TestAdvancePulseLoopWrap(t *testing.T) {
 	}
 }
 
-func TestSeekWhilePlayingLoop(t *testing.T) {
+func TestTimelineDragWhilePlayingKeepsPulse(t *testing.T) {
 	g := New(testLogger)
 	g.Layout(640, 480)
 
@@ -111,16 +111,18 @@ func TestSeekWhilePlayingLoop(t *testing.T) {
 	g.playing = true
 	g.spawnPulseFrom(0)
 	if g.activePulse == nil {
-		t.Fatalf("expected active pulse before seek")
+		t.Fatalf("expected active pulse before drag")
 	}
 
-	g.Seek(10)
+	g.drum.Offset = 10
+	g.drum.offsetChanged = true
+	g.Update()
 
 	if !g.playing {
-		t.Fatalf("playing stopped after seek")
+		t.Fatalf("playing stopped after drag")
 	}
 	if g.activePulse == nil {
-		t.Fatalf("expected active pulse after seek")
+		t.Fatalf("expected active pulse after drag")
 	}
 }
 

--- a/src/go/internal/ui/game_test.go
+++ b/src/go/internal/ui/game_test.go
@@ -93,6 +93,37 @@ func TestAdvancePulseLoopWrap(t *testing.T) {
 	}
 }
 
+func TestSeekWhilePlayingLoop(t *testing.T) {
+	g := New(testLogger)
+	g.Layout(640, 480)
+
+	n1 := g.tryAddNode(0, 0, model.NodeTypeRegular)
+	g.start = n1
+	g.graph.StartNodeID = n1.ID
+	n2 := g.tryAddNode(1, 0, model.NodeTypeRegular)
+	n3 := g.tryAddNode(2, 0, model.NodeTypeRegular)
+	g.addEdge(n1, n2)
+	g.addEdge(n2, n3)
+	g.addEdge(n3, n1)
+
+	g.updateBeatInfos()
+
+	g.playing = true
+	g.spawnPulseFrom(0)
+	if g.activePulse == nil {
+		t.Fatalf("expected active pulse before seek")
+	}
+
+	g.Seek(10)
+
+	if !g.playing {
+		t.Fatalf("playing stopped after seek")
+	}
+	if g.activePulse == nil {
+		t.Fatalf("expected active pulse after seek")
+	}
+}
+
 func TestDrumWheelDoesNotZoomGrid(t *testing.T) {
 	g := New(testLogger)
 	g.Layout(640, 480)

--- a/src/go/internal/ui/theme.go
+++ b/src/go/internal/ui/theme.go
@@ -20,8 +20,8 @@ var (
 	colStepBorder = color.RGBA{60, 60, 60, 255}
 	colHighlight  = color.RGBA{240, 240, 40, 255}
 
-	colTimelineTotal  = color.RGBA{60, 60, 60, 255}
-	colTimelineView   = color.RGBA{120, 120, 120, 255}
+       colTimelineTotal  = color.RGBA{40, 40, 40, 255}
+       colTimelineView   = color.RGBA{0, 160, 200, 255}
 	colTimelineCursor = color.RGBA{240, 240, 40, 255}
 
 	NodeUI   = NodeStyle{Radius: 16, Fill: color.RGBA{80, 80, 80, 255}, Border: color.RGBA{220, 220, 220, 255}}

--- a/src/go/internal/ui/theme.go
+++ b/src/go/internal/ui/theme.go
@@ -13,6 +13,7 @@ var (
 	colBPMBox       = color.RGBA{45, 45, 45, 255}
 	colLenDec       = color.RGBA{70, 130, 180, 255}
 	colLenInc       = color.RGBA{70, 70, 180, 255}
+	colError        = color.RGBA{200, 60, 60, 255}
 
 	colStep       = color.RGBA{0, 160, 200, 255}
 	colStepOff    = color.RGBA{25, 25, 25, 255}

--- a/src/go/internal/ui/theme.go
+++ b/src/go/internal/ui/theme.go
@@ -21,7 +21,7 @@ var (
 
 	NodeUI   = NodeStyle{Radius: 16, Fill: color.RGBA{80, 80, 80, 255}, Border: color.RGBA{220, 220, 220, 255}}
 	SignalUI = SignalStyle{Radius: 6, Color: color.RGBA{0, 160, 200, 255}}
-	EdgeUI   = EdgeStyle{Color: color.RGBA{220, 220, 220, 255}, Thickness: 2, ArrowSize: 8}
+	EdgeUI   = EdgeStyle{Color: color.RGBA{220, 220, 220, 255}, Thickness: 2, ArrowSize: 12}
 
 	PlayButtonStyle = ButtonStyle{Fill: colPlayButton, Border: colButtonBorder}
 	StopButtonStyle = ButtonStyle{Fill: colStopButton, Border: colButtonBorder}

--- a/src/go/internal/ui/theme.go
+++ b/src/go/internal/ui/theme.go
@@ -21,7 +21,7 @@ var (
 
 	NodeUI   = NodeStyle{Radius: 16, Fill: color.RGBA{80, 80, 80, 255}, Border: color.RGBA{220, 220, 220, 255}}
 	SignalUI = SignalStyle{Radius: 6, Color: color.RGBA{0, 160, 200, 255}}
-	EdgeUI   = EdgeStyle{Color: color.RGBA{220, 220, 220, 255}, Thickness: 2, ArrowSize: 12}
+	EdgeUI   = EdgeStyle{Color: color.RGBA{220, 220, 220, 120}, Thickness: 2, ArrowSize: 8}
 
 	PlayButtonStyle = ButtonStyle{Fill: colPlayButton, Border: colButtonBorder}
 	StopButtonStyle = ButtonStyle{Fill: colStopButton, Border: colButtonBorder}

--- a/src/go/internal/ui/theme.go
+++ b/src/go/internal/ui/theme.go
@@ -19,6 +19,10 @@ var (
 	colStepBorder = color.RGBA{60, 60, 60, 255}
 	colHighlight  = color.RGBA{240, 240, 40, 255}
 
+	colTimelineTotal  = color.RGBA{60, 60, 60, 255}
+	colTimelineView   = color.RGBA{120, 120, 120, 255}
+	colTimelineCursor = color.RGBA{240, 240, 40, 255}
+
 	NodeUI   = NodeStyle{Radius: 16, Fill: color.RGBA{80, 80, 80, 255}, Border: color.RGBA{220, 220, 220, 255}}
 	SignalUI = SignalStyle{Radius: 6, Color: color.RGBA{0, 160, 200, 255}}
 	EdgeUI   = EdgeStyle{Color: color.RGBA{220, 220, 220, 120}, Thickness: 2, ArrowSize: 8}

--- a/src/go/internal/ui/theme.go
+++ b/src/go/internal/ui/theme.go
@@ -3,19 +3,40 @@ package ui
 import "image/color"
 
 var (
-	colBGTop    = color.RGBA{20, 20, 30, 255}
-	colBGBottom = color.RGBA{10, 10, 10, 255}
-	colGridLine = color.RGBA{60, 60, 60, 255}
+	colBGTop    = color.RGBA{30, 30, 30, 255}
+	colBGBottom = color.RGBA{20, 20, 20, 255}
+	colGridLine = color.RGBA{50, 50, 50, 255}
 
-	colButtonBorder = color.RGBA{240, 240, 240, 255}
-	colPlayButton   = color.RGBA{40, 200, 40, 255}
-	colStopButton   = color.RGBA{200, 40, 40, 255}
-	colBPMBox       = color.RGBA{40, 40, 40, 255}
-	colLenDec       = color.RGBA{40, 160, 200, 255}
-	colLenInc       = color.RGBA{40, 40, 200, 255}
+	colButtonBorder = color.RGBA{220, 220, 220, 255}
+	colPlayButton   = color.RGBA{60, 170, 90, 255}
+	colStopButton   = color.RGBA{170, 60, 60, 255}
+	colBPMBox       = color.RGBA{45, 45, 45, 255}
+	colLenDec       = color.RGBA{70, 130, 180, 255}
+	colLenInc       = color.RGBA{70, 70, 180, 255}
 
-	colStep       = color.RGBA{0, 200, 255, 255}
-	colStepOff    = color.RGBA{30, 30, 30, 255}
-	colStepBorder = color.RGBA{80, 80, 80, 255}
-	colHighlight  = color.RGBA{255, 255, 0, 255}
+	colStep       = color.RGBA{0, 160, 200, 255}
+	colStepOff    = color.RGBA{25, 25, 25, 255}
+	colStepBorder = color.RGBA{60, 60, 60, 255}
+	colHighlight  = color.RGBA{240, 240, 40, 255}
+
+	NodeUI   = NodeStyle{Radius: 16, Fill: color.RGBA{80, 80, 80, 255}, Border: color.RGBA{220, 220, 220, 255}}
+	SignalUI = SignalStyle{Radius: 6, Color: color.RGBA{0, 160, 200, 255}}
+	EdgeUI   = EdgeStyle{Color: color.RGBA{220, 220, 220, 255}, Thickness: 2, ArrowSize: 8}
+
+	PlayButtonStyle = ButtonStyle{Fill: colPlayButton, Border: colButtonBorder}
+	StopButtonStyle = ButtonStyle{Fill: colStopButton, Border: colButtonBorder}
+	BPMBoxStyle     = TextInputStyle{Fill: colBPMBox, Border: colButtonBorder}
+	BPMDecStyle     = ButtonStyle{Fill: colLenDec, Border: colButtonBorder}
+	BPMIncStyle     = ButtonStyle{Fill: colLenInc, Border: colButtonBorder}
+	LenDecStyle     = ButtonStyle{Fill: colLenDec, Border: colButtonBorder}
+	LenIncStyle     = ButtonStyle{Fill: colLenInc, Border: colButtonBorder}
+	InstButtonStyle = ButtonStyle{Fill: colBPMBox, Border: colButtonBorder}
+	UploadBtnStyle  = ButtonStyle{Fill: colBPMBox, Border: colButtonBorder}
+
+	DrumCellUI = DrumCellStyle{
+		On:        colStep,
+		Off:       colStepOff,
+		Highlight: colHighlight,
+		Border:    colStepBorder,
+	}
 )

--- a/src/go/internal/ui/theme.go
+++ b/src/go/internal/ui/theme.go
@@ -20,8 +20,8 @@ var (
 	colStepBorder = color.RGBA{60, 60, 60, 255}
 	colHighlight  = color.RGBA{240, 240, 40, 255}
 
-       colTimelineTotal  = color.RGBA{40, 40, 40, 255}
-       colTimelineView   = color.RGBA{0, 160, 200, 255}
+	colTimelineTotal  = color.RGBA{40, 40, 40, 255}
+	colTimelineView   = color.RGBA{0, 160, 200, 255}
 	colTimelineCursor = color.RGBA{240, 240, 40, 255}
 
 	NodeUI   = NodeStyle{Radius: 16, Fill: color.RGBA{80, 80, 80, 255}, Border: color.RGBA{220, 220, 220, 255}}

--- a/src/go/internal/ui/transport.go
+++ b/src/go/internal/ui/transport.go
@@ -51,10 +51,7 @@ func (t *Transport) Update() {
 		if ch := inputChars(); len(ch) > 0 {
 			// simplistic numeric entry
 			if d, err := strconv.Atoi(string(ch)); err == nil {
-				newBpm := t.BPM*10 + d
-				if newBpm <= 300 {
-					t.BPM = newBpm
-				}
+				t.BPM = t.BPM*10 + d
 			}
 		}
 		if isKeyPressed(ebiten.KeyBackspace) {

--- a/src/go/internal/ui/transport_test.go
+++ b/src/go/internal/ui/transport_test.go
@@ -1,6 +1,10 @@
 package ui
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
 
 func TestTransportSetBPMClamp(t *testing.T) {
 	tr := NewTransport(200)
@@ -18,5 +22,41 @@ func TestTransportSetBPMClamp(t *testing.T) {
 	}
 	if tr.bpmErrorAnim == 0 {
 		t.Errorf("expected error animation on low bpm")
+	}
+}
+
+func TestTransportBPMTextInput(t *testing.T) {
+	tr := NewTransport(200)
+
+	cx, cy := tr.boxRect.Min.X+1, tr.boxRect.Min.Y+1
+	pressed := true
+	chars := []rune{}
+	restore := SetInputForTest(
+		func() (int, int) { return cx, cy },
+		func(ebiten.MouseButton) bool { return pressed },
+		func(ebiten.Key) bool { return false },
+		func() []rune { c := chars; chars = nil; return c },
+		func() (float64, float64) { return 0, 0 },
+		func() (int, int) { return 200, 200 },
+	)
+	defer restore()
+
+	tr.Update() // click to focus
+	pressed = false
+
+	chars = []rune{'5'}
+	tr.Update()
+	chars = []rune{'0'}
+	tr.Update()
+	chars = []rune{'0'}
+	tr.Update()
+
+	// click outside to commit
+	pressed = true
+	cx, cy = 0, 0
+	tr.Update()
+
+	if tr.BPM != 500 {
+		t.Fatalf("expected BPM 500 got %d", tr.BPM)
 	}
 }

--- a/src/go/internal/ui/transport_test.go
+++ b/src/go/internal/ui/transport_test.go
@@ -1,0 +1,22 @@
+package ui
+
+import "testing"
+
+func TestTransportSetBPMClamp(t *testing.T) {
+	tr := NewTransport(200)
+	tr.SetBPM(maxBPM + 500)
+	if tr.BPM != maxBPM {
+		t.Fatalf("BPM not clamped: %d", tr.BPM)
+	}
+	if tr.bpmErrorAnim == 0 {
+		t.Errorf("expected error animation on high bpm")
+	}
+	tr.bpmErrorAnim = 0
+	tr.SetBPM(0)
+	if tr.BPM != 1 {
+		t.Fatalf("low BPM not clamped: %d", tr.BPM)
+	}
+	if tr.bpmErrorAnim == 0 {
+		t.Errorf("expected error animation on low bpm")
+	}
+}

--- a/src/go/internal/ui/upload_test.go
+++ b/src/go/internal/ui/upload_test.go
@@ -17,7 +17,7 @@ func TestUploadWAVRegistersInstrument(t *testing.T) {
 	// simulate upload selection
 	g.drum.uploading = true
 	g.drum.uploadCh <- uploadResult{path: "dummy.wav", err: nil}
-	g.drum.Update() // process channel, prompt for name
+	g.drum.Update() // process channel
 
 	restore := SetInputForTest(
 		func() (int, int) { return 0, 0 },


### PR DESCRIPTION
## Summary
- Extract core game logic into new `engine` package running in its own goroutine
- Drive UI through engine events and isolate rendering from scheduling logic
- Improved color schemes, animations, buttons, nodes, signals, etc
- Added drum view seekable timeline with BPM and time count
- Adjust demo and tests to use the new engine API

## Testing
- `go test -tags test -modfile=go.test.mod -timeout 1s ./...`
- `make wasm`
- `xvfb-run make test-real`
- `xvfb-run make run RUN_ARGS=-demo`


------
https://chatgpt.com/codex/tasks/task_e_689bb2ef024083318e793328ced2e52e