### PR TITLE
Decouple game engine from UI and revamped UI with seekable timeline

### DIFF
--- a/src/go/core/engine/engine.go
+++ b/src/go/core/engine/engine.go
@@ -1,0 +1,82 @@
+package engine
+
+import (
+	"context"
+	"time"
+
+	"github.com/ingyamilmolinar/tunkul/core/beat"
+	"github.com/ingyamilmolinar/tunkul/core/model"
+	game_log "github.com/ingyamilmolinar/tunkul/internal/log"
+)
+
+// Event represents a tick from the game engine.
+type Event struct {
+	Step int
+}
+
+const tickInterval = 16 * time.Millisecond
+
+// Engine encapsulates the core game logic and runs it on its own goroutine.
+type Engine struct {
+	Graph  *model.Graph
+	sched  *beat.Scheduler
+	Events chan Event
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// New creates a new Engine instance and starts its run loop.
+func New(logger *game_log.Logger) *Engine {
+	graph := model.NewGraph(logger)
+	sched := beat.NewScheduler()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	e := &Engine{
+		Graph:  graph,
+		sched:  sched,
+		Events: make(chan Event, 16),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	sched.OnTick = func(step int) {
+		select {
+		case e.Events <- Event{Step: step}:
+		default:
+		}
+	}
+
+	go e.run()
+	return e
+}
+
+func (e *Engine) run() {
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			e.sched.Tick()
+		case <-e.ctx.Done():
+			return
+		}
+	}
+}
+
+// Start begins the scheduler.
+func (e *Engine) Start() { e.sched.Start() }
+
+// Stop stops the scheduler.
+func (e *Engine) Stop() { e.sched.Stop() }
+
+// SetBPM updates the scheduler BPM.
+func (e *Engine) SetBPM(bpm int) { e.sched.SetBPM(bpm) }
+
+// BPM returns the current scheduler BPM.
+func (e *Engine) BPM() int { return e.sched.BPM }
+
+// Close terminates the engine goroutine.
+func (e *Engine) Close() { e.cancel() }
+
+// BeatLength exposes the scheduler's beat length.
+func (e *Engine) BeatLength() int { return e.sched.BeatLength }

--- a/src/go/internal/ui/bpm.go
+++ b/src/go/internal/ui/bpm.go
@@ -1,0 +1,3 @@
+package ui
+
+const maxBPM = 1000

--- a/src/go/internal/ui/components.go
+++ b/src/go/internal/ui/components.go
@@ -1,0 +1,189 @@
+package ui
+
+import (
+	"image"
+	"image/color"
+	"math"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// pixel helper is defined in widgets.go and reused here.
+
+// fadeColor returns c with its alpha scaled by t (0..1).
+func fadeColor(c color.Color, t float64) color.Color {
+	r, g, b, a := c.RGBA()
+	if t < 0 {
+		t = 0
+	}
+	if t > 1 {
+		t = 1
+	}
+	return color.NRGBA{R: uint8(r >> 8), G: uint8(g >> 8), B: uint8(b >> 8), A: uint8(float64(a>>8) * t)}
+}
+
+// NodeStyle defines visual appearance for graph nodes.
+type NodeStyle struct {
+	Radius float32
+	Fill   color.Color
+	Border color.Color
+}
+
+// Draw renders a node at world coordinates using the provided camera matrix.
+func (s NodeStyle) Draw(dst *ebiten.Image, x, y float64, cam *ebiten.GeoM) {
+	size := float64(s.Radius) * 2
+	var op ebiten.DrawImageOptions
+	op.GeoM.Scale(size, size)
+	op.GeoM.Translate(x-float64(s.Radius), y-float64(s.Radius))
+	op.GeoM.Concat(*cam)
+	dst.DrawImage(pixel(s.Fill), &op)
+	DrawLineCam(dst, x-float64(s.Radius), y-float64(s.Radius), x+float64(s.Radius), y-float64(s.Radius), cam, s.Border, 1)
+	DrawLineCam(dst, x+float64(s.Radius), y-float64(s.Radius), x+float64(s.Radius), y+float64(s.Radius), cam, s.Border, 1)
+	DrawLineCam(dst, x+float64(s.Radius), y+float64(s.Radius), x-float64(s.Radius), y+float64(s.Radius), cam, s.Border, 1)
+	DrawLineCam(dst, x-float64(s.Radius), y+float64(s.Radius), x-float64(s.Radius), y-float64(s.Radius), cam, s.Border, 1)
+}
+
+// SignalStyle defines the appearance of travelling pulses between nodes.
+type SignalStyle struct {
+	Radius float32
+	Color  color.Color
+}
+
+// Draw renders the signal at world coordinates with the given camera transform.
+func (s SignalStyle) Draw(dst *ebiten.Image, x, y float64, cam *ebiten.GeoM) {
+	size := float64(s.Radius) * 2
+	// Outer glow
+	var op ebiten.DrawImageOptions
+	glowSize := size * 1.5
+	op.GeoM.Scale(glowSize, glowSize)
+	op.GeoM.Translate(x-glowSize/2, y-glowSize/2)
+	op.GeoM.Concat(*cam)
+	dst.DrawImage(pixel(fadeColor(s.Color, 0.3)), &op)
+
+	// Inner core
+	var op2 ebiten.DrawImageOptions
+	op2.GeoM.Scale(size, size)
+	op2.GeoM.Translate(x-size/2, y-size/2)
+	op2.GeoM.Concat(*cam)
+	dst.DrawImage(pixel(s.Color), &op2)
+}
+
+// EdgeStyle draws directional edges between nodes.
+type EdgeStyle struct {
+	Color     color.Color
+	Thickness float64
+	ArrowSize float64
+}
+
+// Draw renders a directed edge from (x1,y1) to (x2,y2) using cam.
+func (s EdgeStyle) Draw(dst *ebiten.Image, x1, y1, x2, y2 float64, cam *ebiten.GeoM) {
+	s.DrawProgress(dst, x1, y1, x2, y2, cam, 1)
+}
+
+// DrawProgress renders a portion of the edge according to progress t
+// (0..1). When t reaches 1 the arrow head is drawn.
+func (s EdgeStyle) DrawProgress(dst *ebiten.Image, x1, y1, x2, y2 float64, cam *ebiten.GeoM, t float64) {
+	if t <= 0 {
+		return
+	}
+	if t > 1 {
+		t = 1
+	}
+	col := fadeColor(s.Color, t)
+	ex := x1 + (x2-x1)*t
+	ey := y1 + (y2-y1)*t
+	DrawLineCam(dst, x1, y1, ex, ey, cam, col, s.Thickness)
+	if t < 1 {
+		return
+	}
+	angle := math.Atan2(y2-y1, x2-x1)
+
+	// Arrowhead at the end of the edge
+	leftX := x2 - s.ArrowSize*math.Cos(angle-math.Pi/6)
+	leftY := y2 - s.ArrowSize*math.Sin(angle-math.Pi/6)
+	rightX := x2 - s.ArrowSize*math.Cos(angle+math.Pi/6)
+	rightY := y2 - s.ArrowSize*math.Sin(angle+math.Pi/6)
+	DrawLineCam(dst, x2, y2, leftX, leftY, cam, col, s.Thickness)
+	DrawLineCam(dst, x2, y2, rightX, rightY, cam, col, s.Thickness)
+
+	// Permanent direction marker at midpoint
+	mx := (x1 + x2) / 2
+	my := (y1 + y2) / 2
+	midLeftX := mx - s.ArrowSize*math.Cos(angle-math.Pi/6)
+	midLeftY := my - s.ArrowSize*math.Sin(angle-math.Pi/6)
+	midRightX := mx - s.ArrowSize*math.Cos(angle+math.Pi/6)
+	midRightY := my - s.ArrowSize*math.Sin(angle+math.Pi/6)
+	DrawLineCam(dst, mx, my, midLeftX, midLeftY, cam, col, s.Thickness)
+	DrawLineCam(dst, mx, my, midRightX, midRightY, cam, col, s.Thickness)
+}
+
+// ButtonStyle describes rectangular button visuals.
+type ButtonStyle struct {
+	Fill   color.Color
+	Border color.Color
+}
+
+// Draw renders the button rectangle using the global drawButton primitive.
+func (s ButtonStyle) Draw(dst *ebiten.Image, r image.Rectangle, pressed bool) {
+	drawButton(dst, r, s.Fill, s.Border, pressed)
+}
+
+// DrawAnimated draws the button with a shrink animation controlled by anim
+// (0..1). anim is typically set to 1 on click and decays toward 0.
+func (s ButtonStyle) DrawAnimated(dst *ebiten.Image, r image.Rectangle, pressed bool, anim float64) {
+	if anim < 0 {
+		anim = 0
+	}
+	inset := int(anim * float64(r.Dx()) * 0.1)
+	animRect := image.Rect(r.Min.X+inset, r.Min.Y+inset, r.Max.X-inset, r.Max.Y-inset)
+	drawButton(dst, animRect, s.Fill, s.Border, pressed)
+}
+
+// TextInputStyle styles a text input box.
+type TextInputStyle struct {
+	Fill   color.Color
+	Border color.Color
+}
+
+// Draw renders the text box using drawButton for consistency.
+func (s TextInputStyle) Draw(dst *ebiten.Image, r image.Rectangle, focused bool) {
+	drawButton(dst, r, s.Fill, s.Border, focused)
+}
+
+// DrawAnimated draws the text box with a subtle focus animation.
+func (s TextInputStyle) DrawAnimated(dst *ebiten.Image, r image.Rectangle, focused bool, anim float64) {
+	if anim < 0 {
+		anim = 0
+	}
+	inset := int(anim * float64(r.Dx()) * 0.1)
+	animRect := image.Rect(r.Min.X+inset, r.Min.Y+inset, r.Max.X-inset, r.Max.Y-inset)
+	drawButton(dst, animRect, s.Fill, s.Border, focused)
+}
+
+// DrumCellStyle styles individual drum machine cells.
+type DrumCellStyle struct {
+	On        color.Color
+	Off       color.Color
+	Highlight color.Color
+	Border    color.Color
+}
+
+// Draw renders a drum cell considering its state. onCol overrides the default On color.
+func (s DrumCellStyle) Draw(dst *ebiten.Image, r image.Rectangle, on, highlighted bool, onCol color.Color) {
+	fill := s.Off
+	if on {
+		if onCol != nil {
+			fill = onCol
+		} else {
+			fill = s.On
+		}
+	}
+	if highlighted {
+		fill = s.Highlight
+	}
+	drawRect(dst, r, fill, true)
+	drawRect(dst, r, s.Border, false)
+}
+
+// DrumRowStyle is reserved for future customisation of entire rows.
+type DrumRowStyle struct{}

--- a/src/go/internal/ui/demo.go
+++ b/src/go/internal/ui/demo.go
@@ -13,8 +13,8 @@ func (g *Game) RunDemo() {
 	b := g.tryAddNode(5, 1, model.NodeTypeRegular)
 	g.addEdge(a, b)
 	g.playing = true
-	g.sched.Start()
-	g.spawnPulse()
+	g.engine.Start()
+	g.spawnPulseFrom(0)
 	go func() {
 		time.Sleep(2 * time.Second)
 		g.logger.Infof("[DEMO] Finished demo run")

--- a/src/go/internal/ui/drawing.go
+++ b/src/go/internal/ui/drawing.go
@@ -27,5 +27,35 @@ var drawButton = func(dst *ebiten.Image, r image.Rectangle, fill, border color.C
 		}
 	}
 	vector.DrawFilledRect(dst, float32(r.Min.X), float32(r.Min.Y), float32(r.Dx()), float32(r.Dy()), fc, false)
+
+	// 3D bevel effect: lighter top/left, darker bottom/right.
+	lx0, ly0 := float32(r.Min.X), float32(r.Min.Y)
+	lx1, ly1 := float32(r.Max.X-1), float32(r.Max.Y-1)
+	light := adjustColor(fc, 40)
+	dark := adjustColor(fc, -40)
+	vector.DrawFilledRect(dst, lx0, ly0, lx1-lx0+1, 1, light, false)
+	vector.DrawFilledRect(dst, lx0, ly0, 1, ly1-ly0+1, light, false)
+	vector.DrawFilledRect(dst, lx0, ly1, lx1-lx0+1, 1, dark, false)
+	vector.DrawFilledRect(dst, lx1, ly0, 1, ly1-ly0+1, dark, false)
+
 	vector.StrokeRect(dst, float32(r.Min.X), float32(r.Min.Y), float32(r.Dx()), float32(r.Dy()), 1, border, false)
+}
+
+// adjustColor lightens or darkens a color by delta (-255..255).
+func adjustColor(c color.Color, delta int) color.Color {
+	r, g, b, a := c.RGBA()
+	rr := clamp(int(r>>8)+delta, 0, 255)
+	gg := clamp(int(g>>8)+delta, 0, 255)
+	bb := clamp(int(b>>8)+delta, 0, 255)
+	return color.RGBA{uint8(rr), uint8(gg), uint8(bb), uint8(a >> 8)}
+}
+
+func clamp(v, min, max int) int {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
 }

--- a/src/go/internal/ui/drumview_test.go
+++ b/src/go/internal/ui/drumview_test.go
@@ -81,7 +81,7 @@ func TestDrumViewWheelAdjustsLength(t *testing.T) {
 	dv := NewDrumView(image.Rect(0, 0, 800, 100), graph, logger)
 
 	wheelVal := 1.0
-	cursor := func() (int, int) { return dv.Bounds.Min.X + dv.labelW + 500, dv.Bounds.Min.Y + 5 }
+	cursor := func() (int, int) { return dv.Bounds.Min.X + dv.labelW + 500, dv.Bounds.Min.Y + timelineHeight + 5 }
 	restore := SetInputForTest(cursor,
 		func(ebiten.MouseButton) bool { return false },
 		func(ebiten.Key) bool { return false },
@@ -115,6 +115,95 @@ func TestDrumViewLengthMinMax(t *testing.T) {
 	drumView.Update()
 	if drumView.Length != 64 {
 		t.Errorf("Expected drum view length to stay at 64, got %d", drumView.Length)
+	}
+}
+
+func TestTimelineInfo(t *testing.T) {
+	logger := game_log.New(io.Discard, game_log.LevelDebug)
+	graph := model.NewGraph(logger)
+	dv := NewDrumView(image.Rect(0, 0, 100, 100), graph, logger)
+	dv.bpm = 120
+	info := dv.timelineInfo(4)
+	expected := "00:02.000/00:04.000 | View 00:00.000-00:04.000 | Beats 1-8/8"
+	if info != expected {
+		t.Fatalf("expected %q got %q", expected, info)
+	}
+}
+
+func TestTimelineViewRect(t *testing.T) {
+	logger := game_log.New(io.Discard, game_log.LevelDebug)
+	graph := model.NewGraph(logger)
+	dv := NewDrumView(image.Rect(0, 0, 800, 200), graph, logger)
+	dv.SetBeatLength(16)
+	dv.Offset = 4
+	dv.recalcButtons()
+
+	var got image.Rectangle
+	orig := drawRect
+	drawRect = func(dst *ebiten.Image, r image.Rectangle, c color.Color, filled bool) {
+		if filled {
+			if clr, ok := c.(color.RGBA); ok && clr == colTimelineView {
+				got = r
+			}
+		}
+	}
+	defer func() { drawRect = orig }()
+
+	dv.Draw(ebiten.NewImage(800, 200), nil, 0, nil, 0)
+
+	totalBeats := dv.timelineBeats
+	start := dv.timelineRect.Min.X + int(float64(dv.Offset)/float64(totalBeats)*float64(dv.timelineRect.Dx()))
+	width := int(float64(dv.Length) / float64(totalBeats) * float64(dv.timelineRect.Dx()))
+	want := image.Rect(start, dv.timelineRect.Min.Y, start+width, dv.timelineRect.Max.Y)
+	if got != want {
+		t.Fatalf("view rect = %v want %v", got, want)
+	}
+}
+
+func TestTimelineLayout(t *testing.T) {
+	logger := game_log.New(io.Discard, game_log.LevelDebug)
+	graph := model.NewGraph(logger)
+	dv := NewDrumView(image.Rect(0, 0, 800, 200), graph, logger)
+	dv.recalcButtons()
+	textY := dv.Bounds.Min.Y + 5
+	if textY >= dv.timelineRect.Min.Y {
+		t.Fatalf("info text overlaps timeline bar")
+	}
+	rowStart := dv.Bounds.Min.Y + timelineHeight
+	if dv.timelineRect.Max.Y >= rowStart {
+		t.Fatalf("timeline bar overlaps drum rows")
+	}
+}
+
+func TestTimelineExpandsAndViewShrinks(t *testing.T) {
+	logger := game_log.New(io.Discard, game_log.LevelDebug)
+	graph := model.NewGraph(logger)
+	dv := NewDrumView(image.Rect(0, 0, 800, 200), graph, logger)
+	dv.recalcButtons()
+	img := ebiten.NewImage(800, 200)
+
+	var rect image.Rectangle
+	orig := drawRect
+	drawRect = func(dst *ebiten.Image, r image.Rectangle, c color.Color, filled bool) {
+		if filled {
+			if clr, ok := c.(color.RGBA); ok && clr == colTimelineView {
+				rect = r
+			}
+		}
+	}
+	defer func() { drawRect = orig }()
+
+	dv.Draw(img, nil, 0, nil, 0)
+	baseWidth := rect.Dx()
+
+	dv.Draw(img, nil, 0, nil, 20)
+	expandedWidth := rect.Dx()
+
+	if dv.timelineBeats != 28 {
+		t.Fatalf("timelineBeats = %d want 28", dv.timelineBeats)
+	}
+	if expandedWidth >= baseWidth {
+		t.Fatalf("view width did not shrink: base %d expanded %d", baseWidth, expandedWidth)
 	}
 }
 
@@ -229,7 +318,7 @@ func TestDrumViewLoopHighlighting(t *testing.T) {
 	// Simulate starting playback
 	game.playing = true
 	game.updateBeatInfos() // Call updateBeatInfos after drum is set
-	game.spawnPulse()
+	game.spawnPulseFrom(0)
 
 	// Run for a few cycles to test loop highlighting
 	for i := 0; i < 20; i++ { // Simulate 20 frames
@@ -284,7 +373,7 @@ func TestDrumViewButtonsDrawn(t *testing.T) {
 	}
 	defer func() { drawButton = orig }()
 
-	dv.Draw(ebiten.NewImage(400, 100), map[int]int64{}, 0, nil)
+	dv.Draw(ebiten.NewImage(400, 100), map[int]int64{}, 0, nil, 0)
 	if count != 9 {
 		t.Fatalf("expected 9 buttons drawn, got %d", count)
 	}
@@ -308,24 +397,87 @@ func TestDrumViewDrawHighlightsInvisibleCells(t *testing.T) {
 	game := &Game{graph: graph, drum: dv, logger: logger}
 	game.updateBeatInfos()
 
-	type call struct{ c color.Color }
+	type call struct {
+		c color.Color
+		r image.Rectangle
+	}
 	calls := []call{}
 	orig := drawRect
 	drawRect = func(dst *ebiten.Image, r image.Rectangle, c color.Color, filled bool) {
-		calls = append(calls, call{c: c})
+		calls = append(calls, call{c: c, r: r})
 	}
 	defer func() { drawRect = orig }()
 
 	highlighted := map[int]int64{1: 1}
-	dv.Draw(ebiten.NewImage(300, 50), highlighted, 0, game.beatInfos)
+	dv.Draw(ebiten.NewImage(300, 50), highlighted, 0, game.beatInfos, 0)
 
 	var highlightCount int
 	for _, call := range calls {
-		if clr, ok := call.c.(color.RGBA); ok && clr.R == 255 && clr.G == 255 && clr.B == 0 && clr.A == 255 {
+		if clr, ok := call.c.(color.RGBA); ok && clr == colHighlight && call.r.Min.Y >= timelineHeight {
 			highlightCount++
 		}
 	}
 	if highlightCount != 1 {
 		t.Fatalf("expected 1 highlight draw, got %d", highlightCount)
+	}
+}
+
+func TestDrumViewSetBPMClamp(t *testing.T) {
+	logger := game_log.New(io.Discard, game_log.LevelError)
+	graph := model.NewGraph(logger)
+	dv := NewDrumView(image.Rect(0, 0, 100, 100), graph, logger)
+	dv.SetBPM(maxBPM + 10)
+	if dv.bpm != maxBPM {
+		t.Fatalf("expected BPM %d, got %d", maxBPM, dv.bpm)
+	}
+	if dv.bpmErrorAnim == 0 {
+		t.Errorf("expected error animation on high bpm")
+	}
+	dv.bpmErrorAnim = 0
+	dv.SetBPM(0)
+	if dv.bpm != 1 {
+		t.Fatalf("expected BPM 1, got %d", dv.bpm)
+	}
+	if dv.bpmErrorAnim == 0 {
+		t.Errorf("expected error animation on low bpm")
+	}
+}
+
+func TestDrumViewBPMTextInput(t *testing.T) {
+	logger := game_log.New(io.Discard, game_log.LevelDebug)
+	graph := model.NewGraph(logger)
+	dv := NewDrumView(image.Rect(0, 0, 400, 200), graph, logger)
+	dv.recalcButtons()
+
+	cx, cy := dv.bpmBox.Min.X+1, dv.bpmBox.Min.Y+1
+	pressed := true
+	chars := []rune{}
+	restore := SetInputForTest(
+		func() (int, int) { return cx, cy },
+		func(ebiten.MouseButton) bool { return pressed },
+		func(ebiten.Key) bool { return false },
+		func() []rune { c := chars; chars = nil; return c },
+		func() (float64, float64) { return 0, 0 },
+		func() (int, int) { return 800, 600 },
+	)
+	defer restore()
+
+	dv.Update() // click to focus
+	pressed = false
+
+	chars = []rune{'5'}
+	dv.Update()
+	chars = []rune{'0'}
+	dv.Update()
+	chars = []rune{'0'}
+	dv.Update()
+
+	// click outside to commit
+	pressed = true
+	cx, cy = 0, 0
+	dv.Update()
+
+	if dv.BPM() != 500 {
+		t.Fatalf("expected BPM 500 got %d", dv.BPM())
 	}
 }

--- a/src/go/internal/ui/theme.go
+++ b/src/go/internal/ui/theme.go
@@ -3,19 +3,45 @@ package ui
 import "image/color"
 
 var (
-	colBGTop    = color.RGBA{20, 20, 30, 255}
-	colBGBottom = color.RGBA{10, 10, 10, 255}
-	colGridLine = color.RGBA{60, 60, 60, 255}
+	colBGTop    = color.RGBA{30, 30, 30, 255}
+	colBGBottom = color.RGBA{20, 20, 20, 255}
+	colGridLine = color.RGBA{50, 50, 50, 255}
 
-	colButtonBorder = color.RGBA{240, 240, 240, 255}
-	colPlayButton   = color.RGBA{40, 200, 40, 255}
-	colStopButton   = color.RGBA{200, 40, 40, 255}
-	colBPMBox       = color.RGBA{40, 40, 40, 255}
-	colLenDec       = color.RGBA{40, 160, 200, 255}
-	colLenInc       = color.RGBA{40, 40, 200, 255}
+	colButtonBorder = color.RGBA{220, 220, 220, 255}
+	colPlayButton   = color.RGBA{60, 170, 90, 255}
+	colStopButton   = color.RGBA{170, 60, 60, 255}
+	colBPMBox       = color.RGBA{45, 45, 45, 255}
+	colLenDec       = color.RGBA{70, 130, 180, 255}
+	colLenInc       = color.RGBA{70, 70, 180, 255}
+	colError        = color.RGBA{200, 60, 60, 255}
 
-	colStep       = color.RGBA{0, 200, 255, 255}
-	colStepOff    = color.RGBA{30, 30, 30, 255}
-	colStepBorder = color.RGBA{80, 80, 80, 255}
-	colHighlight  = color.RGBA{255, 255, 0, 255}
+	colStep       = color.RGBA{0, 160, 200, 255}
+	colStepOff    = color.RGBA{25, 25, 25, 255}
+	colStepBorder = color.RGBA{60, 60, 60, 255}
+	colHighlight  = color.RGBA{240, 240, 40, 255}
+
+	colTimelineTotal  = color.RGBA{40, 40, 40, 255}
+	colTimelineView   = color.RGBA{0, 160, 200, 255}
+	colTimelineCursor = color.RGBA{240, 240, 40, 255}
+
+	NodeUI   = NodeStyle{Radius: 16, Fill: color.RGBA{80, 80, 80, 255}, Border: color.RGBA{220, 220, 220, 255}}
+	SignalUI = SignalStyle{Radius: 6, Color: color.RGBA{0, 160, 200, 255}}
+	EdgeUI   = EdgeStyle{Color: color.RGBA{220, 220, 220, 120}, Thickness: 2, ArrowSize: 8}
+
+	PlayButtonStyle = ButtonStyle{Fill: colPlayButton, Border: colButtonBorder}
+	StopButtonStyle = ButtonStyle{Fill: colStopButton, Border: colButtonBorder}
+	BPMBoxStyle     = TextInputStyle{Fill: colBPMBox, Border: colButtonBorder}
+	BPMDecStyle     = ButtonStyle{Fill: colLenDec, Border: colButtonBorder}
+	BPMIncStyle     = ButtonStyle{Fill: colLenInc, Border: colButtonBorder}
+	LenDecStyle     = ButtonStyle{Fill: colLenDec, Border: colButtonBorder}
+	LenIncStyle     = ButtonStyle{Fill: colLenInc, Border: colButtonBorder}
+	InstButtonStyle = ButtonStyle{Fill: colBPMBox, Border: colButtonBorder}
+	UploadBtnStyle  = ButtonStyle{Fill: colBPMBox, Border: colButtonBorder}
+
+	DrumCellUI = DrumCellStyle{
+		On:        colStep,
+		Off:       colStepOff,
+		Highlight: colHighlight,
+		Border:    colStepBorder,
+	}
 )

--- a/src/go/internal/ui/transport_test.go
+++ b/src/go/internal/ui/transport_test.go
@@ -1,0 +1,62 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+func TestTransportSetBPMClamp(t *testing.T) {
+	tr := NewTransport(200)
+	tr.SetBPM(maxBPM + 500)
+	if tr.BPM != maxBPM {
+		t.Fatalf("BPM not clamped: %d", tr.BPM)
+	}
+	if tr.bpmErrorAnim == 0 {
+		t.Errorf("expected error animation on high bpm")
+	}
+	tr.bpmErrorAnim = 0
+	tr.SetBPM(0)
+	if tr.BPM != 1 {
+		t.Fatalf("low BPM not clamped: %d", tr.BPM)
+	}
+	if tr.bpmErrorAnim == 0 {
+		t.Errorf("expected error animation on low bpm")
+	}
+}
+
+func TestTransportBPMTextInput(t *testing.T) {
+	tr := NewTransport(200)
+
+	cx, cy := tr.boxRect.Min.X+1, tr.boxRect.Min.Y+1
+	pressed := true
+	chars := []rune{}
+	restore := SetInputForTest(
+		func() (int, int) { return cx, cy },
+		func(ebiten.MouseButton) bool { return pressed },
+		func(ebiten.Key) bool { return false },
+		func() []rune { c := chars; chars = nil; return c },
+		func() (float64, float64) { return 0, 0 },
+		func() (int, int) { return 200, 200 },
+	)
+	defer restore()
+
+	tr.Update() // click to focus
+	pressed = false
+
+	chars = []rune{'5'}
+	tr.Update()
+	chars = []rune{'0'}
+	tr.Update()
+	chars = []rune{'0'}
+	tr.Update()
+
+	// click outside to commit
+	pressed = true
+	cx, cy = 0, 0
+	tr.Update()
+
+	if tr.BPM != 500 {
+		t.Fatalf("expected BPM 500 got %d", tr.BPM)
+	}
+}

--- a/src/go/internal/ui/upload_test.go
+++ b/src/go/internal/ui/upload_test.go
@@ -17,7 +17,7 @@ func TestUploadWAVRegistersInstrument(t *testing.T) {
 	// simulate upload selection
 	g.drum.uploading = true
 	g.drum.uploadCh <- uploadResult{path: "dummy.wav", err: nil}
-	g.drum.Update() // process channel, prompt for name
+	g.drum.Update() // process channel
 
 	restore := SetInputForTest(
 		func() (int, int) { return 0, 0 },


### PR DESCRIPTION
Summary

    Extract core game logic into new engine package running in its own goroutine
    Drive UI through engine events and isolate rendering from scheduling logic
    Improved color schemes, animations, buttons, nodes, signals, etc
    Added drum view seekable timeline with BPM and time count
    Adjust demo and tests to use the new engine API

Testing

    go test -tags test -modfile=go.test.mod -timeout 1s ./...
    make wasm
    xvfb-run make test-real
    xvfb-run make run RUN_ARGS=-demo

https://chatgpt.com/codex/tasks/task_e_689bb2ef024083318e793328ced2e52e
